### PR TITLE
Move license notice to README

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,24 +1,7 @@
-Copyright (c) 2021 juancarloscp52
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-
-
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -648,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -662,14 +645,14 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -681,12 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
-
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can find the built JARs inside Entropy/build/libs
 
 Copyright (C) 2021 juancarloscp52 and the Entropy contributors
 
-Entropy is released under [`GPL-3.0-or-later`],
+Entropy is released under [GPL-3.0-or-later],
 a free software and Open Source license.
 
-[`GPL-3.0-or-later`]: COPYING "SPDX-License-Identifier: GPL-3.0-or-later"
+[GPL-3.0-or-later]: COPYING "SPDX-License-Identifier: GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -48,5 +48,11 @@ gradlew build
 ```
 You can find the built JARs inside Entropy/build/libs
 
-## License
-Entropy is released under the free and open-source [GPL-3.0 License](https://github.com/juancarloscp52/Entropy/blob/master/LICENSE).
+## Copyright
+
+Copyright (C) 2021 juancarloscp52 and the Entropy contributors
+
+Entropy is released under [`GPL-3.0-or-later`],
+a free software and Open Source license.
+
+[`GPL-3.0-or-later`]: COPYING "SPDX-License-Identifier: GPL-3.0-or-later"


### PR DESCRIPTION
This would allow GitHub to automatically recognize the license.