### PR TITLE
Cinematic Camera Fix

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/db/CinematicScreenEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/CinematicScreenEvent.java
@@ -38,6 +38,12 @@ public class CinematicScreenEvent extends AbstractTimedEvent {
     }
 
     @Override
+    public void tickClient() {
+        client = MinecraftClient.getInstance();
+        client.options.smoothCameraEnabled = true;
+    }
+
+    @Override
     public void endClient() {
         this.hasEnded = true;
         client = MinecraftClient.getInstance();


### PR DESCRIPTION
If you set up button to toggle cinematic camera in the Options > Controls you was able to turn off smooth mouse movement while cinematic camera was active. No more.