### PR TITLE
🆕 Teleport to the `end` event

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -33,6 +33,7 @@ public class EventRegistry {
     public static void register() {
 
         entropyEvents = new HashMap<>();
+        entropyEvents.put("TeleportToEndEvent", TeleportToEndEvent::new);
         entropyEvents.put("ArrowRainEvent", ArrowRainEvent::new);
         entropyEvents.put("WardenEvent", WardenEvent::new);
         entropyEvents.put("BlurEvent", BlurEvent::new);

--- a/src/main/java/me/juancarloscp52/entropy/events/db/TeleportToEndEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/TeleportToEndEvent.java
@@ -1,0 +1,29 @@
+package me.juancarloscp52.entropy.events.db;
+
+import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.events.AbstractInstantEvent;
+import net.minecraft.block.Blocks;
+import net.minecraft.server.world.ServerWorld;
+
+public class TeleportToEndEvent extends AbstractInstantEvent {
+
+    @Override
+    public void init() {
+        Entropy.getInstance().eventHandler.getActivePlayers().forEach(player -> {
+            var end = player.server.getWorld(ServerWorld.END);
+
+
+            // set spawnpoint if there is any
+            if(player.getSpawnPointPosition()==null){
+                player.setSpawnPoint(ServerWorld.OVERWORLD, player.getBlockPos(),0,true,false);
+            }
+            // place an enderchest in the overworld player's spawnpoint
+            player.getWorld().setBlockState(player.getSpawnPointPosition(), Blocks.ENDER_CHEST.getDefaultState());
+            // teleport to end
+            player.moveToWorld(end);
+            // place an enderchest in the end
+            end.setBlockState(player.getBlockPos(), Blocks.ENDER_CHEST.getDefaultState());
+
+        });
+    }
+}

--- a/src/main/resources/assets/entropy/lang/en_gb.json
+++ b/src/main/resources/assets/entropy/lang/en_gb.json
@@ -102,6 +102,8 @@
   "entropy.events.FlyingMachineEvent": "Flying Machine",
   "entropy.events.AddHeartEvent": "Add Heart",
   "entropy.events.RemoveHeartEvent": "Remove Heart",
+  "entropy.events.TeleportToEndEvent": "Right to the end!",
+
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Error",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -124,6 +124,7 @@
   "entropy.events.FlyingMachineEvent": "Flying Machine",
   "entropy.events.AddHeartEvent": "Add Heart",
   "entropy.events.RemoveHeartEvent": "Remove Heart",
+  "entropy.events.TeleportToEndEvent": "Right to the end!",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Error",


### PR DESCRIPTION
* Set the player's `Spawnpoint` at player position if there was not any before
* Creates an `Enderchest` at the spawnpoint
* Teleport the player to the `end`
* Creates  an `Enderchest` in end (teleport position)

I think this event is well balanced as the player can save his stuff in the enderchest in the end and get it back after his death (at the spawnpoint)

## TODO
* [ ] Check how that works when being in the nether or end already