### PR TITLE
Bin folder ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ run/
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+
+# vscode
+bin/


### PR DESCRIPTION
vscode will always generate `bin/` folder that i always have to stage out for commits.
Adding `bin/` folder will prevent mistakes like #30 or #37 (incorrectly placed translation files)