### PR TITLE
XRay Event

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/Variables.java
+++ b/src/main/java/me/juancarloscp52/entropy/Variables.java
@@ -51,4 +51,5 @@ public class Variables {
     public static boolean explodingPickaxe = false;
     public static boolean flipEntities = false;
     public static boolean forceSneak = false;
+    public static boolean xrayActive = false;
 }

--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -162,6 +162,7 @@ public class EventRegistry {
         entropyEvents.put("AddHeartEvent", AddHeartEvent::new);
         entropyEvents.put("RemoveHeartEvent", RemoveHeartEvent::new);
         entropyEvents.put("NoiseMachineEvent", NoiseMachineEvent::new);
+        entropyEvents.put("XRayEvent", XRayEvent::new);
 
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/events/db/XRayEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/XRayEvent.java
@@ -1,0 +1,79 @@
+package me.juancarloscp52.entropy.events.db;
+
+import java.util.ArrayList;
+
+import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.Variables;
+import me.juancarloscp52.entropy.events.AbstractTimedEvent;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.client.MinecraftClient;
+
+public class XRayEvent extends AbstractTimedEvent {
+
+    public static final ArrayList<Block> BLOCKS_TO_RENDER = new ArrayList<Block>() {{
+        add(Blocks.COAL_ORE);
+        add(Blocks.COAL_BLOCK);
+        add(Blocks.DEEPSLATE_COAL_ORE);
+        add(Blocks.IRON_ORE);
+        add(Blocks.RAW_IRON_BLOCK);
+        add(Blocks.IRON_BLOCK);
+        add(Blocks.DEEPSLATE_IRON_ORE);
+        add(Blocks.COPPER_ORE);
+        add(Blocks.RAW_COPPER_BLOCK);
+        add(Blocks.COPPER_BLOCK);
+        add(Blocks.DEEPSLATE_COPPER_ORE);
+        add(Blocks.GOLD_ORE);
+        add(Blocks.RAW_GOLD_BLOCK);
+        add(Blocks.NETHER_GOLD_ORE);
+        add(Blocks.GOLD_BLOCK);
+        add(Blocks.DEEPSLATE_GOLD_ORE);
+        add(Blocks.DIAMOND_ORE);
+        add(Blocks.DIAMOND_BLOCK);
+        add(Blocks.DEEPSLATE_DIAMOND_ORE);
+        add(Blocks.ANCIENT_DEBRIS);
+        add(Blocks.NETHERITE_BLOCK);
+        add(Blocks.LAPIS_ORE);
+        add(Blocks.LAPIS_BLOCK);
+        add(Blocks.DEEPSLATE_LAPIS_ORE);
+        add(Blocks.EMERALD_ORE);
+        add(Blocks.EMERALD_BLOCK);
+        add(Blocks.DEEPSLATE_EMERALD_ORE);
+        add(Blocks.REDSTONE_ORE);
+        add(Blocks.REDSTONE_BLOCK);
+        add(Blocks.DEEPSLATE_REDSTONE_ORE);
+        add(Blocks.BEDROCK);
+        add(Blocks.OBSIDIAN);
+    }};
+
+    @Override
+    public void initClient() {
+        Variables.xrayActive = true;
+
+        // Rerender the world because of the caching
+        var client = MinecraftClient.getInstance();
+        client.worldRenderer.reload();
+    }
+
+    @Override
+    public void endClient() {
+        Variables.xrayActive = false;
+        
+        // Rerender the world because of the caching
+        var client = MinecraftClient.getInstance();
+        client.worldRenderer.reload();
+        
+        this.hasEnded = true;
+    }
+
+    @Override
+    public void render(MatrixStack matrixStack, float tickdelta) {
+    }
+
+    @Override
+    public short getDuration() {
+        return Entropy.getInstance().settings.baseEventDuration;
+    }
+
+}

--- a/src/main/java/me/juancarloscp52/entropy/mixin/AbstractBlockStateMixin.java
+++ b/src/main/java/me/juancarloscp52/entropy/mixin/AbstractBlockStateMixin.java
@@ -1,0 +1,72 @@
+package me.juancarloscp52.entropy.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import me.juancarloscp52.entropy.Variables;
+import me.juancarloscp52.entropy.events.db.XRayEvent;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.SideShapeType;
+import net.minecraft.block.AbstractBlock.AbstractBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+import net.minecraft.world.BlockView;
+
+@Mixin(AbstractBlockState.class)
+public abstract class AbstractBlockStateMixin {
+    @Shadow
+    public abstract Block getBlock();
+
+    // BlockMixin's shouldDrawSide function is enough for vanilla, but in order for the event to work with Sodium, isSideInvisible and isSideSolid need to be modified
+    @Inject(at = @At("HEAD"), method = "isSideInvisible", cancellable = true)
+    public void isSideInvisible(BlockState state, Direction direction, CallbackInfoReturnable<Boolean> ci) {
+        if (Variables.xrayActive) {
+            ci.setReturnValue(!XRayEvent.BLOCKS_TO_RENDER.contains(this.getBlock()));
+            return;
+        }
+    }
+
+    @Inject(at = @At("HEAD"), method = "isSideSolid", cancellable = true)
+    public void isSideSolid(BlockView world, BlockPos pos, Direction direction, SideShapeType shapeType, CallbackInfoReturnable<Boolean> ci) {
+        if (Variables.xrayActive) {
+            ci.setReturnValue(XRayEvent.BLOCKS_TO_RENDER.contains(this.getBlock()));
+            return;
+        }
+    }
+
+    // Make interested blocks glow
+    @Inject(at = @At("HEAD"), method = "getAmbientOcclusionLightLevel", cancellable = true)
+    public void getAmbientOcclusionLightLevel(BlockView world, BlockPos pos, CallbackInfoReturnable<Float> ci) {
+        if (Variables.xrayActive) {
+            ci.setReturnValue(1f);
+            return;
+        }
+    }
+
+    // And make these blocks highlight its surroundings
+    @Inject(at = @At("HEAD"), method = "getLuminance", cancellable = true)
+    public void getLuminance(CallbackInfoReturnable<Integer> ci) {
+        if (Variables.xrayActive && XRayEvent.BLOCKS_TO_RENDER.contains(this.getBlock())) {
+            ci.setReturnValue(12);
+            return;
+        }
+    }
+
+    // getCullingFace needs to be modified in order to work with Sodium. Without it if block is next to the stone then only face next to the air is rendered.
+    @Inject(at = @At("HEAD"), method = "getCullingFace", cancellable = true)
+    public void getCullingFace(CallbackInfoReturnable<VoxelShape> ci) {
+        if (Variables.xrayActive) {
+            if (XRayEvent.BLOCKS_TO_RENDER.contains(this.getBlock()))
+                ci.setReturnValue(VoxelShapes.fullCube());
+            else
+                ci.setReturnValue(VoxelShapes.empty());
+            return;
+        }
+    }
+}

--- a/src/main/java/me/juancarloscp52/entropy/mixin/BlockMixin.java
+++ b/src/main/java/me/juancarloscp52/entropy/mixin/BlockMixin.java
@@ -18,6 +18,7 @@
 package me.juancarloscp52.entropy.mixin;
 
 import me.juancarloscp52.entropy.Variables;
+import me.juancarloscp52.entropy.events.db.XRayEvent;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
@@ -29,16 +30,16 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.random.Random;
+import net.minecraft.world.BlockView;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
-import net.minecraft.world.explosion.Explosion;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 
 @Mixin(Block.class)
 public class BlockMixin {
@@ -92,6 +93,14 @@ public class BlockMixin {
     private void changeSlipperiness(CallbackInfoReturnable<Float> cir) {
         if (Variables.slippery)
             cir.setReturnValue(1.02f);
+    }
+
+    @Inject(method = "shouldDrawSide", at = @At("HEAD"), cancellable = true)
+    private static void shouldDrawSide(BlockState state, BlockView world, BlockPos pos,
+                                       Direction side, BlockPos otherPos, CallbackInfoReturnable<Boolean> ci) {
+        if (Variables.xrayActive) {
+            ci.setReturnValue(XRayEvent.BLOCKS_TO_RENDER.contains(state.getBlock()));
+        }
     }
 
 }

--- a/src/main/resources/assets/entropy/lang/en_gb.json
+++ b/src/main/resources/assets/entropy/lang/en_gb.json
@@ -106,6 +106,7 @@
   "entropy.events.RaidEvent": "Prepare to fight!",
   "entropy.events.RemoveEnchantmentsEvent": "You lost some magic",
   "entropy.events.NoiseMachineEvent": "Chimes",
+  "entropy.events.XRayEvent": "XRay",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Error",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -128,6 +128,7 @@
   "entropy.events.RaidEvent": "Prepare to fight!",
   "entropy.events.RemoveEnchantmentsEvent": "You lost some magic",
   "entropy.events.NoiseMachineEvent": "Chimes",
+  "entropy.events.XRayEvent": "XRay",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Error",

--- a/src/main/resources/entropy.mixins.json
+++ b/src/main/resources/entropy.mixins.json
@@ -4,6 +4,7 @@
   "package": "me.juancarloscp52.entropy.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
+    "AbstractBlockStateMixin",
     "BlockMixin",
     "EntityMixin"
   ],


### PR DESCRIPTION
Make blocks that not ore, mineral blocks, obsidian or bedrock to not render.
Sodium compatible.

I didn't figure out how to make all chunks render. There seems to be some kind of optimization that doesn't display chunks if they are completely surrounded by full blocks.