### PR TITLE
Fix events not respecting feature flags

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/db/ItemRainEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/ItemRainEvent.java
@@ -25,7 +25,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.math.random.Random;
-
+import net.minecraft.world.World;
 
 public class ItemRainEvent extends AbstractTimedEvent {
 
@@ -55,7 +55,8 @@ public class ItemRainEvent extends AbstractTimedEvent {
         if (getTickCount() % 15 == 0) {
             for (int i = 0; i < 5; i++) {
                 Entropy.getInstance().eventHandler.getActivePlayers().forEach(serverPlayerEntity -> {
-                    ItemEntity item = new ItemEntity(serverPlayerEntity.getWorld(), serverPlayerEntity.getX() + (random.nextInt(100) - 50), serverPlayerEntity.getY() + 50 + (random.nextInt(10) - 5), serverPlayerEntity.getZ() + (random.nextInt(100) - 50), new ItemStack(getRandomItem(), 1));
+                    World world = serverPlayerEntity.getWorld();
+                    ItemEntity item = new ItemEntity(world, serverPlayerEntity.getX() + (random.nextInt(100) - 50), serverPlayerEntity.getY() + 50 + (random.nextInt(10) - 5), serverPlayerEntity.getZ() + (random.nextInt(100) - 50), new ItemStack(getRandomItem(world), 1));
                     serverPlayerEntity.getWorld().spawnEntity(item);
                 });
             }
@@ -63,12 +64,12 @@ public class ItemRainEvent extends AbstractTimedEvent {
         super.tick();
     }
 
-    private Item getRandomItem() {
+    private Item getRandomItem(World world) {
         Item item = Registries.ITEM.getRandom(Random.create()).get().value();
         if (item.toString().equals("debug_stick") || item.toString().contains("spawn_egg") || item.toString().contains("command_block") || item.toString().contains("structure_void") || item.toString().contains("barrier")) {
-            item = getRandomItem();
+            item = getRandomItem(world);
         }
-        return item;
+        return item.getRequiredFeatures().isSubsetOf(world.getEnabledFeatures()) ? item : getRandomItem(world);
     }
 
     @Override

--- a/src/main/java/me/juancarloscp52/entropy/mixin/BlockMixin.java
+++ b/src/main/java/me/juancarloscp52/entropy/mixin/BlockMixin.java
@@ -54,7 +54,7 @@ public class BlockMixin {
                 double xOffset = (double) (world.random.nextFloat() * radius) + 0.25D;
                 double yOffset = (double) (world.random.nextFloat() * radius) + 0.25D;
                 double zOffset = (double) (world.random.nextFloat() * radius) + 0.25D;
-                ItemEntity itemEntity = new ItemEntity(world, (double) pos.getX() + xOffset, (double) pos.getY() + yOffset, (double) pos.getZ() + zOffset, computeItemStack(stack));
+                ItemEntity itemEntity = new ItemEntity(world, (double) pos.getX() + xOffset, (double) pos.getY() + yOffset, (double) pos.getZ() + zOffset, computeItemStack(stack, world));
                 itemEntity.setToDefaultPickupDelay();
                 world.spawnEntity(itemEntity);
             }
@@ -70,22 +70,22 @@ public class BlockMixin {
         }
     }
 
-    private static ItemStack computeItemStack(ItemStack itemStack) {
+    private static ItemStack computeItemStack(ItemStack itemStack, World world) {
         if (Variables.luckyDrops) {
             itemStack.setCount(itemStack.getCount() * 5);
             return itemStack;
         } else if (Variables.randomDrops) {
-            return new ItemStack(getRandomItem(), itemStack.getCount());
+            return new ItemStack(getRandomItem(world), itemStack.getCount());
         }
         return null;
     }
 
-    private static Item getRandomItem() {
+    private static Item getRandomItem(World world) {
         Item item = Registries.ITEM.getRandom(Random.create()).get().value();
         if (item.toString().equals("debug_stick") || item.toString().contains("spawn_egg") || item.toString().contains("command_block") || item.toString().contains("structure_void") || item.toString().contains("barrier")) {
-            item = getRandomItem();
+            item = getRandomItem(world);
         }
-        return item;
+        return item.getRequiredFeatures().isSubsetOf(world.getEnabledFeatures()) ? item : getRandomItem(world);
     }
 
     @Inject(method = "getSlipperiness", at = @At("RETURN"), cancellable = true)

--- a/src/main/java/me/juancarloscp52/entropy/mixin/EntityMixin.java
+++ b/src/main/java/me/juancarloscp52/entropy/mixin/EntityMixin.java
@@ -85,7 +85,7 @@ public abstract class EntityMixin {
         if (item.toString().equals("debug_stick") || item.toString().contains("spawn_egg") || item.toString().contains("command_block") || item.toString().contains("structure_void") || item.toString().contains("barrier")) {
             item = getRandomItem();
         }
-        return item;
+        return item.getRequiredFeatures().isSubsetOf(world.getEnabledFeatures()) ? item : getRandomItem();
     }
 
 }


### PR DESCRIPTION
Minecraft 1.19.3 added feature flags, which control whether an item, entity, etc. shows up in game. They are currently used to enable or disable content from the experimental datapacks for bundles and 1.20. As an example: If the update_1_20 datapack is not enabled, Entropy will, for instance during the random drops event, still drop items that are part of that datapack (the bamboo blocks are one example). With the changes from this PR, those experimental items will only drop when the corresponding experimental datapack is enabled.