### PR TITLE
Add a simple search bar to the event configuration screen

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/client/Screens/EntropyEventConfigurationScreen.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/Screens/EntropyEventConfigurationScreen.java
@@ -25,6 +25,7 @@ import me.juancarloscp52.entropy.client.Screens.Widgets.EntropyEventListWidget;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.util.math.MatrixStack;
 
 import net.minecraft.screen.ScreenTexts;
@@ -32,6 +33,7 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 public class EntropyEventConfigurationScreen extends Screen {
     private static final Identifier LOGO = new Identifier("entropy", "textures/logo-with-text.png");
@@ -47,7 +49,7 @@ public class EntropyEventConfigurationScreen extends Screen {
     }
 
     protected void init() {
-        list = new EntropyEventListWidget(MinecraftClient.getInstance(), this.width, this.height, 32, this.height - 32, 25);
+        list = new EntropyEventListWidget(MinecraftClient.getInstance(), this.width, this.height, 56, this.height - 32, 25);
         list.addAllFromRegistry();
         this.addSelectableChild(list);
         // Done button
@@ -61,6 +63,30 @@ public class EntropyEventConfigurationScreen extends Screen {
         ButtonWidget uncheckAll = ButtonWidget.builder(Text.translatable("entropy.options.uncheckAllEvents"), button -> onUncheckAll()).position(this.width / 2 - 100 + 200, this.height - 26).width(100).build();
         this.addDrawableChild(uncheckAll);
 
+        // Search box
+        Text searchText = Text.translatable("entropy.options.search");
+        TextFieldWidget search = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, this.width / 2 - 100, 29, 200, 20, searchText);
+        search.setPlaceholder(searchText);
+        search.setChangedListener(newText -> {
+            String lowerCasedNewText = newText.toLowerCase(Locale.ROOT);
+            list.visibleEntries.clear();
+
+        	if (newText.isBlank())
+                list.children().stream().forEach(buttonEntry -> {
+                    buttonEntry.button.visible = true;
+                    list.visibleEntries.add(buttonEntry);
+                });
+        	else {
+                list.children().stream().forEach(buttonEntry -> {
+                    buttonEntry.button.visible = buttonEntry.eventName.toLowerCase(Locale.ROOT).contains(lowerCasedNewText) || buttonEntry.eventID.toLowerCase(Locale.ROOT).contains(lowerCasedNewText);
+
+                    if(buttonEntry.button.visible)
+                        list.visibleEntries.add(buttonEntry);
+                });
+                list.setScrollAmount(0.0D);
+            }
+        });
+        this.addDrawableChild(search);
     }
 
     public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
@@ -98,13 +124,13 @@ public class EntropyEventConfigurationScreen extends Screen {
 
     private void onCheckAll() {
         this.list.children().forEach(buttonEntry -> {
-            if (!buttonEntry.button.isChecked()) {buttonEntry.button.onPress();}
+            if (buttonEntry.button.visible && !buttonEntry.button.isChecked()) {buttonEntry.button.onPress();}
         });
     }
 
     private void onUncheckAll() {
         this.list.children().forEach(buttonEntry -> {
-            if (buttonEntry.button.isChecked()) {buttonEntry.button.onPress();}
+            if (buttonEntry.button.visible && buttonEntry.button.isChecked()) {buttonEntry.button.onPress();}
         });
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/client/Screens/EntropyEventConfigurationScreen.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/Screens/EntropyEventConfigurationScreen.java
@@ -71,12 +71,12 @@ public class EntropyEventConfigurationScreen extends Screen {
             String lowerCasedNewText = newText.toLowerCase(Locale.ROOT);
             list.visibleEntries.clear();
 
-        	if (newText.isBlank())
+            if (newText.isBlank())
                 list.children().stream().forEach(buttonEntry -> {
                     buttonEntry.button.visible = true;
                     list.visibleEntries.add(buttonEntry);
                 });
-        	else {
+            else {
                 list.children().stream().forEach(buttonEntry -> {
                     buttonEntry.button.visible = buttonEntry.eventName.toLowerCase(Locale.ROOT).contains(lowerCasedNewText) || buttonEntry.eventID.toLowerCase(Locale.ROOT).contains(lowerCasedNewText);
 

--- a/src/main/java/me/juancarloscp52/entropy/client/Screens/Widgets/EntropyEventListWidget.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/Screens/Widgets/EntropyEventListWidget.java
@@ -77,7 +77,7 @@ public class EntropyEventListWidget extends ElementListWidget<EntropyEventListWi
 
     @Override
     protected int getEntryCount() {
-    	return this.visibleEntries.size();
+        return this.visibleEntries.size();
     }
 
     @Override

--- a/src/main/java/me/juancarloscp52/entropy/client/Screens/Widgets/EntropyEventListWidget.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/Screens/Widgets/EntropyEventListWidget.java
@@ -29,7 +29,9 @@ import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.Selectable;
 import net.minecraft.client.gui.widget.CheckboxWidget;
 import net.minecraft.client.gui.widget.ElementListWidget;
+import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.Text;
 import net.minecraft.util.Pair;
 import net.minecraft.util.math.MathHelper;
@@ -157,6 +159,7 @@ public class EntropyEventListWidget extends ElementListWidget<EntropyEventListWi
         @Override
         public boolean mouseClicked(double mouseX, double mouseY, int button) {
             this.button.onPress();
+            MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(SoundEvents.UI_BUTTON_CLICK, 1.0F));
             return true;
         }
 

--- a/src/main/java/me/juancarloscp52/entropy/mixin/EntryListWidgetAccessor.java
+++ b/src/main/java/me/juancarloscp52/entropy/mixin/EntryListWidgetAccessor.java
@@ -1,13 +1,8 @@
 package me.juancarloscp52.entropy.mixin;
 
-import net.minecraft.client.gui.hud.BossBarHud;
-import net.minecraft.client.gui.hud.ClientBossBar;
 import net.minecraft.client.gui.widget.EntryListWidget;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
-
-import java.util.Map;
-import java.util.UUID;
 
 @Mixin(EntryListWidget.class)
 public interface EntryListWidgetAccessor {

--- a/src/main/java/me/juancarloscp52/entropy/mixin/EntryListWidgetAccessor.java
+++ b/src/main/java/me/juancarloscp52/entropy/mixin/EntryListWidgetAccessor.java
@@ -1,0 +1,18 @@
+package me.juancarloscp52.entropy.mixin;
+
+import net.minecraft.client.gui.hud.BossBarHud;
+import net.minecraft.client.gui.hud.ClientBossBar;
+import net.minecraft.client.gui.widget.EntryListWidget;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Mixin(EntryListWidget.class)
+public interface EntryListWidgetAccessor {
+
+    @Accessor
+    boolean getScrolling();
+
+}

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -158,6 +158,7 @@
   "entropy.options.integrations.youtube.error.auth": "Autorisierung fehlgeschlagen",
 
   "entropy.options.disableEvents": "Ereignisse Deaktivieren",
+  "entropy.options.search": "Suchen...",
   "entropy.options.eventDuration": "Ereignis Dauer: %ds",
   "entropy.options.timerDuration": "Timer Dauer: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -158,6 +158,7 @@
   "entropy.options.integrations.youtube.error.auth": "Autorisierung fehlgeschlagen",
 
   "entropy.options.disableEvents": "Ereignisse Deaktivieren",
+  "entropy.options.search": "Suchen...",
   "entropy.options.eventDuration": "Ereignis Dauer: %ds",
   "entropy.options.timerDuration": "Timer Dauer: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -158,6 +158,7 @@
   "entropy.options.integrations.youtube.error.auth": "Autorisierung fehlgeschlagen",
 
   "entropy.options.disableEvents": "Ereignisse Deaktivieren",
+  "entropy.options.search": "Suchen...",
   "entropy.options.eventDuration": "Ereignis Dauer: %ds",
   "entropy.options.timerDuration": "Timer Dauer: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -160,6 +160,7 @@
   "entropy.options.integrations.youtube.error.auth": "Failed to authorize",
 
   "entropy.options.disableEvents": "Disable Events",
+  "entropy.options.search": "Search...",
   "entropy.options.eventDuration": "Base Event Duration: %ds",
   "entropy.options.timerDuration": "Timer Duration: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/assets/entropy/lang/es_ar.json
+++ b/src/main/resources/assets/entropy/lang/es_ar.json
@@ -159,6 +159,7 @@
   "entropy.options.integrations.youtube.error.auth": "Fallo al autorizar",
 
   "entropy.options.disableEvents": "Desactivar eventos",
+  "entropy.options.search": "Buscar...",
   "entropy.options.eventDuration": "Duración base de eventos: %ds",
   "entropy.options.timerDuration": "Duración del contador: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/assets/entropy/lang/es_cl.json
+++ b/src/main/resources/assets/entropy/lang/es_cl.json
@@ -159,6 +159,7 @@
   "entropy.options.integrations.youtube.error.auth": "Fallo al autorizar",
 
   "entropy.options.disableEvents": "Desactivar eventos",
+  "entropy.options.search": "Buscar...",
   "entropy.options.eventDuration": "Duración base de eventos: %ds",
   "entropy.options.timerDuration": "Duración del contador: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/assets/entropy/lang/es_ec.json
+++ b/src/main/resources/assets/entropy/lang/es_ec.json
@@ -159,6 +159,7 @@
   "entropy.options.integrations.youtube.error.auth": "Fallo al autorizar",
 
   "entropy.options.disableEvents": "Desactivar eventos",
+  "entropy.options.search": "Buscar...",
   "entropy.options.eventDuration": "Duración base de eventos: %ds",
   "entropy.options.timerDuration": "Duración del contador: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -159,6 +159,7 @@
   "entropy.options.integrations.youtube.error.auth": "Fallo al autorizar",
 
   "entropy.options.disableEvents": "Desactivar eventos",
+  "entropy.options.search": "Buscar...",
   "entropy.options.eventDuration": "Duración base de eventos: %ds",
   "entropy.options.timerDuration": "Duración del contador: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/assets/entropy/lang/es_mx.json
+++ b/src/main/resources/assets/entropy/lang/es_mx.json
@@ -159,6 +159,7 @@
   "entropy.options.integrations.youtube.error.auth": "Fallo al autorizar",
 
   "entropy.options.disableEvents": "Desactivar eventos",
+  "entropy.options.search": "Buscar...",
   "entropy.options.eventDuration": "Duración base de eventos: %ds",
   "entropy.options.timerDuration": "Duración del contador: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/assets/entropy/lang/es_uy.json
+++ b/src/main/resources/assets/entropy/lang/es_uy.json
@@ -159,6 +159,7 @@
   "entropy.options.integrations.youtube.error.auth": "Fallo al autorizar",
 
   "entropy.options.disableEvents": "Desactivar eventos",
+  "entropy.options.search": "Buscar...",
   "entropy.options.eventDuration": "Duración base de eventos: %ds",
   "entropy.options.timerDuration": "Duración del contador: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/assets/entropy/lang/es_ve.json
+++ b/src/main/resources/assets/entropy/lang/es_ve.json
@@ -159,6 +159,7 @@
   "entropy.options.integrations.youtube.error.auth": "Fallo al autorizar",
 
   "entropy.options.disableEvents": "Desactivar eventos",
+  "entropy.options.search": "Buscar...",
   "entropy.options.eventDuration": "Duración base de eventos: %ds",
   "entropy.options.timerDuration": "Duración del contador: %ds",
   "entropy.options.questionMark": "?",

--- a/src/main/resources/entropy.mixins.json
+++ b/src/main/resources/entropy.mixins.json
@@ -15,6 +15,7 @@
     "ClientPlayerEntityMixin",
     "ClientPlayerInteractionManagerMixin",
     "ClientWorldMixin",
+    "EntryListWidgetAccessor",
     "GameRendererMixin",
     "KeyboardInputMixin",
     "LivingEntityRendererMixin",


### PR DESCRIPTION
This makes it easier to find the event the user is looking for. The "Enable All" and "Disable All" buttons only apply to the events that are currently shown as per the search. Here's a short showcase:

https://user-images.githubusercontent.com/5149876/211216570-99f76cbc-b443-42fb-863a-b78a4a4667de.mp4

Additionally, I fixed clicking the checkboxes not making a sound. I didn't feel like creating a separate pull request for this, especially because it's within the same screen this PR modifies.