### PR TITLE
FPS ≠ View distance

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/db/LowFPSEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/LowFPSEvent.java
@@ -38,7 +38,7 @@ public class LowFPSEvent extends AbstractTimedEvent {
     public void endClient() {
         this.hasEnded = true;
         client = MinecraftClient.getInstance();
-        this.client.options.getViewDistance().setValue(fps);
+        this.client.options.getMaxFps().setValue(fps);
     }
 
     @Override


### PR DESCRIPTION
Fix the Low FPS event setting the view distance instead of the FPS when the timer expires.

Note: I haven't technically tested this, but I don't see how it could fail.