### PR TITLE
Add haunted chests event

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -168,6 +168,7 @@ public class EventRegistry {
         entropyEvents.put("RandomCameraTiltEvent", RandomCameraTiltEvent::new);
         entropyEvents.put("NoAttackingEvent", NoAttackingEvent::new);
         entropyEvents.put("ConstantAttackingEvent", ConstantAttackingEvent::new);
+        entropyEvents.put("HauntedChestsEvent", HauntedChestsEvent::new);
 
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/events/db/HauntedChestsEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/HauntedChestsEvent.java
@@ -1,0 +1,82 @@
+package me.juancarloscp52.entropy.events.db;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.events.AbstractTimedEvent;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.ChestBlockEntity;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.WorldChunk;
+
+public class HauntedChestsEvent extends AbstractTimedEvent {
+    private List<ChestBlockEntity> openedChests = new ArrayList<>();
+
+    @Override
+    public void tickClient() {
+        super.tick();
+
+        if(tickCount % 20 == 0) {
+            PlayerEntity player = MinecraftClient.getInstance().player;
+            BlockPos.Mutable pos = player.getBlockPos().mutableCopy();
+            World world = player.getWorld();
+            boolean chestOpened = false;
+            boolean chestClosed = false;
+
+            for(int x = -16; x <= 16; x += 16) {
+                for(int z = -16; z <= 16; z += 16) {
+                    pos.set(pos.getX() + x, pos.getY(), pos.getZ() + z);
+
+                    WorldChunk chunk = world.getWorldChunk(pos);
+
+                    for(BlockEntity be : chunk.getBlockEntityPositions().stream().map(chunk::getBlockEntity).toList()) {
+                        if(player.getRandom().nextInt(10) >= 7 && be instanceof ChestBlockEntity chest) {
+                            if(openedChests.contains(chest)) {
+                                chest.onClose(player);
+                                openedChests.remove(chest);
+                                chestClosed = true;
+                            }
+                            else {
+                                chest.onOpen(player);
+                                openedChests.add(chest);
+                                chestOpened = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if(chestOpened)
+                player.playSound(SoundEvents.BLOCK_CHEST_OPEN, 1f, 1f);
+
+            if(chestClosed)
+                player.playSound(SoundEvents.BLOCK_CHEST_CLOSE, 1f, 1f);
+        }
+    }
+
+    @Override
+    public void endClient() {
+        super.endClient();
+        PlayerEntity player = MinecraftClient.getInstance().player;
+
+        if(openedChests.size() > 0) {
+            openedChests.forEach(chest -> chest.onClose(player));
+            openedChests.clear();
+            player.playSound(SoundEvents.BLOCK_CHEST_CLOSE, 1f, 1f);
+        }
+    }
+
+    @Override
+    public void render(MatrixStack matrixStack, float tickdelta) {}
+
+    @Override
+    public short getDuration() {
+        return Entropy.getInstance().settings.baseEventDuration;
+    }
+}

--- a/src/main/java/me/juancarloscp52/entropy/events/db/HauntedChestsEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/HauntedChestsEvent.java
@@ -20,7 +20,7 @@ public class HauntedChestsEvent extends AbstractTimedEvent {
 
     @Override
     public void tickClient() {
-        super.tick();
+        super.tickClient();
 
         if(tickCount % 20 == 0) {
             PlayerEntity player = MinecraftClient.getInstance().player;

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -132,6 +132,7 @@
   "entropy.events.RandomCameraTiltEvent": "Schräge Kamera",
   "entropy.events.NoAttackingEvent": "Attackieren nicht erlaubt",
   "entropy.events.ConstantAttackingEvent": "Andauerndes Attackieren",
+  "entropy.events.HauntedChestsEvent": "Spukende Truhen",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Fehler",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -132,6 +132,7 @@
   "entropy.events.RandomCameraTiltEvent": "Schräge Kamera",
   "entropy.events.NoAttackingEvent": "Attackieren nicht erlaubt",
   "entropy.events.ConstantAttackingEvent": "Andauerndes Attackieren",
+  "entropy.events.HauntedChestsEvent": "Spukende Truhen",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Fehler",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -132,6 +132,7 @@
   "entropy.events.RandomCameraTiltEvent": "Schräge Kamera",
   "entropy.events.NoAttackingEvent": "Attackieren nicht erlaubt",
   "entropy.events.ConstantAttackingEvent": "Andauerndes Attackieren",
+  "entropy.events.HauntedChestsEvent": "Spukende Truhen",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Fehler",

--- a/src/main/resources/assets/entropy/lang/en_gb.json
+++ b/src/main/resources/assets/entropy/lang/en_gb.json
@@ -111,6 +111,7 @@
   "entropy.events.RandomCameraTiltEvent": "Tilted camera",
   "entropy.events.NoAttackingEvent": "No attacking allowed",
   "entropy.events.ConstantAttackingEvent": "Constant attacking",
+  "entropy.events.HauntedChestsEvent": "Haunted Chests",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Error",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -134,6 +134,7 @@
   "entropy.events.RandomCameraTiltEvent": "Tilted Camera",
   "entropy.events.NoAttackingEvent": "No Attacking Allowed",
   "entropy.events.ConstantAttackingEvent": "Constant Attacking",
+  "entropy.events.HauntedChestsEvent": "Haunted Chests",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Error",

--- a/src/main/resources/assets/entropy/lang/es_ar.json
+++ b/src/main/resources/assets/entropy/lang/es_ar.json
@@ -134,6 +134,7 @@
   "entropy.events.RandomCameraTiltEvent": "Cámara rotada",
   "entropy.events.NoAttackingEvent": "Prohibido atacar",
   "entropy.events.ConstantAttackingEvent": "Atacar constantemente",
+  "entropy.events.HauntedChestsEvent": "Cofres encantados",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy error",

--- a/src/main/resources/assets/entropy/lang/es_cl.json
+++ b/src/main/resources/assets/entropy/lang/es_cl.json
@@ -134,6 +134,7 @@
   "entropy.events.RandomCameraTiltEvent": "Cámara rotada",
   "entropy.events.NoAttackingEvent": "Prohibido atacar",
   "entropy.events.ConstantAttackingEvent": "Atacar constantemente",
+  "entropy.events.HauntedChestsEvent": "Cofres encantados",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy error",

--- a/src/main/resources/assets/entropy/lang/es_ec.json
+++ b/src/main/resources/assets/entropy/lang/es_ec.json
@@ -134,6 +134,7 @@
   "entropy.events.RandomCameraTiltEvent": "Cámara rotada",
   "entropy.events.NoAttackingEvent": "Prohibido atacar",
   "entropy.events.ConstantAttackingEvent": "Atacar constantemente",
+  "entropy.events.HauntedChestsEvent": "Cofres encantados",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy error",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -134,6 +134,7 @@
   "entropy.events.RandomCameraTiltEvent": "Cámara rotada",
   "entropy.events.NoAttackingEvent": "Prohibido atacar",
   "entropy.events.ConstantAttackingEvent": "Atacar constantemente",
+  "entropy.events.HauntedChestsEvent": "Cofres encantados",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy error",

--- a/src/main/resources/assets/entropy/lang/es_mx.json
+++ b/src/main/resources/assets/entropy/lang/es_mx.json
@@ -134,6 +134,7 @@
   "entropy.events.RandomCameraTiltEvent": "Cámara rotada",
   "entropy.events.NoAttackingEvent": "Prohibido atacar",
   "entropy.events.ConstantAttackingEvent": "Atacar constantemente",
+  "entropy.events.HauntedChestsEvent": "Cofres encantados",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy error",

--- a/src/main/resources/assets/entropy/lang/es_uy.json
+++ b/src/main/resources/assets/entropy/lang/es_uy.json
@@ -134,6 +134,7 @@
   "entropy.events.RandomCameraTiltEvent": "Cámara rotada",
   "entropy.events.NoAttackingEvent": "Prohibido atacar",
   "entropy.events.ConstantAttackingEvent": "Atacar constantemente",
+  "entropy.events.HauntedChestsEvent": "Cofres encantados",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy error",

--- a/src/main/resources/assets/entropy/lang/es_ve.json
+++ b/src/main/resources/assets/entropy/lang/es_ve.json
@@ -134,6 +134,7 @@
   "entropy.events.RandomCameraTiltEvent": "Cámara rotada",
   "entropy.events.NoAttackingEvent": "Prohibido atacar",
   "entropy.events.ConstantAttackingEvent": "Atacar constantemente",
+  "entropy.events.HauntedChestsEvent": "Cofres encantados",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy error",


### PR DESCRIPTION
The haunted chests event randomly opens and closes chests in the chunks around the player. This is done client side, so one player won't see the same chests open as another one. I figured this would add to the "hauntedness".
Here's a short showcase:

https://user-images.githubusercontent.com/5149876/212045798-2208e306-ed38-4caa-bb5e-001d3238e5a1.mp4

