### PR TITLE
Add button to events configuration screen for filtering events by whether they are enabled

### DIFF
--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -186,6 +186,10 @@
   "entropy.options.integrations.showPollStatus": "Umfragestatus auf dem Bildschirm anzeigen",
   "entropy.options.checkAllEvents": "Alle Aktivieren",
   "entropy.options.uncheckAllEvents": "Alle Deaktivieren",
+  "entropy.options.filterEvents": "Ereignisse filtern",
+  "entropy.options.all": "Alle",
+  "entropy.options.enabled": "Aktiviert",
+  "entropy.options.disabled": "Deaktiviert",
   "entropy.options.ui": "Runterzählen-Stil: %s",
   "entropy.options.ui.GTAV": "Chaos Mod",
   "entropy.options.ui.MINECRAFT": "Minecraft"

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -186,6 +186,10 @@
   "entropy.options.integrations.showPollStatus": "Umfragestatus auf dem Bildschirm anzeigen",
   "entropy.options.checkAllEvents": "Alle Aktivieren",
   "entropy.options.uncheckAllEvents": "Alle Deaktivieren",
+  "entropy.options.filterEvents": "Ereignisse filtern",
+  "entropy.options.all": "Alle",
+  "entropy.options.enabled": "Aktiviert",
+  "entropy.options.disabled": "Deaktiviert",
   "entropy.options.ui": "Runterzählen-Stil: %s",
   "entropy.options.ui.GTAV": "Chaos Mod",
   "entropy.options.ui.MINECRAFT": "Minecraft"

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -186,6 +186,10 @@
   "entropy.options.integrations.showPollStatus": "Umfragestatus auf dem Bildschirm anzeigen",
   "entropy.options.checkAllEvents": "Alle Aktivieren",
   "entropy.options.uncheckAllEvents": "Alle Deaktivieren",
+  "entropy.options.filterEvents": "Ereignisse filtern",
+  "entropy.options.all": "Alle",
+  "entropy.options.enabled": "Aktiviert",
+  "entropy.options.disabled": "Deaktiviert",
   "entropy.options.ui": "Timer-Stil: %s",
   "entropy.options.ui.GTAV": "Chaos Mod",
   "entropy.options.ui.MINECRAFT": "Minecraft"

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -187,6 +187,10 @@
   "entropy.options.integrations.showPollStatus": "Show poll status on screen",
   "entropy.options.checkAllEvents": "Enable All",
   "entropy.options.uncheckAllEvents": "Disable All",
+  "entropy.options.filterEvents": "Filter Events",
+  "entropy.options.all": "All",
+  "entropy.options.enabled": "Enabled",
+  "entropy.options.disabled": "Disabled",
   "entropy.options.ui": "Countdown Style: %s",
   "entropy.options.ui.GTAV": "Chaos Mod",
   "entropy.options.ui.MINECRAFT": "Minecraft"

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -185,5 +185,9 @@
   "entropy.options.integrations.showPollStatus": "Mostrar estado de la encuesta en pantalla",
   "entropy.options.checkAllEvents": "Seleccionar todos",
   "entropy.options.uncheckAllEvents": "Deseleccionar todos",
+  "entropy.options.filterEvents": "Filtrar eventos",
+  "entropy.options.all": "Todos",
+  "entropy.options.enabled": "Activos",
+  "entropy.options.disabled": "Inactivos",
   "entropy.options.ui": "Estilo: %s"
 }


### PR DESCRIPTION
This PR adds a button to the event configuration screen which allows the player to only show events that are enabled, or only ones that are disabled. If a search term is entered, the button only operates on the displayed events.
Another small change is setting the search bar to automatically be focused when the screen is opened, so the player can type right away without having to manually select the search bar first. This behavior matches the vanilla singleplayer select world screen.
Here's a short showcase of the new filter button:

https://user-images.githubusercontent.com/5149876/213004857-d42608dd-9819-4c17-ab0b-5be628f41c5c.mp4

