### PR TITLE
Add black and white shader event

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/Variables.java
+++ b/src/main/java/me/juancarloscp52/entropy/Variables.java
@@ -55,4 +55,5 @@ public class Variables {
     public static float cameraRoll = 0f;
     public static boolean stuttering = false;
     public static boolean forceRiding = false;
+    public static boolean blackAndWhite = false;
 }

--- a/src/main/java/me/juancarloscp52/entropy/client/EntropyClient.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/EntropyClient.java
@@ -59,6 +59,7 @@ public class EntropyClient implements ClientModInitializer {
     private PostEffectProcessor shader_wobble;
     private PostEffectProcessor shader_invertedColor;
     private PostEffectProcessor shader_monitor;
+    private PostEffectProcessor shader_black_and_white;
     public static EntropyClient getInstance() {
         return instance;
     }
@@ -206,7 +207,15 @@ public class EntropyClient implements ClientModInitializer {
         }
     }
 
-
+    public void renderBlackAndWhite(float tickDelta) {
+        if (Variables.blackAndWhite) {
+            if(shader_black_and_white==null){
+                shader_black_and_white=ShaderManager.register(new Identifier("entropy", "shaders/post/black_and_white.json"));
+            }
+            assert shader_black_and_white != null : "Black & White shader is null";
+            ShaderManager.render(shader_black_and_white,tickDelta);
+        }
+    }
 
     public void loadSettings() {
         File file = new File("./config/entropy/entropyIntegrationSettings.json");

--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -180,6 +180,7 @@ public class EventRegistry {
         entropyEvents.put("ForceHorseRidingEvent", ForceHorseRidingEvent::new);
         entropyEvents.put("JumpscareEvent", JumpscareEvent::new);
         entropyEvents.put("RollingCameraEvent", RollingCameraEvent::new);
+        entropyEvents.put("BlackAndWhiteEvent", BlackAndWhiteEvent::new);
 
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/events/db/BlackAndWhiteEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/BlackAndWhiteEvent.java
@@ -1,0 +1,32 @@
+package me.juancarloscp52.entropy.events.db;
+
+import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.Variables;
+import me.juancarloscp52.entropy.events.AbstractTimedEvent;
+import net.minecraft.client.util.math.MatrixStack;
+
+public class BlackAndWhiteEvent extends AbstractTimedEvent {
+    @Override
+    public void initClient() {
+        Variables.blackAndWhite = true;
+    }
+
+    @Override
+    public void endClient() {
+        Variables.blackAndWhite = false;
+        this.hasEnded = true;
+    }
+
+    @Override
+    public void render(MatrixStack matrixStack, float tickdelta) {}
+
+    @Override
+    public String type() {
+        return "shader";
+    }
+
+    @Override
+    public short getDuration() {
+        return Entropy.getInstance().settings.baseEventDuration;
+    }
+}

--- a/src/main/java/me/juancarloscp52/entropy/events/db/BlackAndWhiteEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/BlackAndWhiteEvent.java
@@ -27,6 +27,6 @@ public class BlackAndWhiteEvent extends AbstractTimedEvent {
 
     @Override
     public short getDuration() {
-        return Entropy.getInstance().settings.baseEventDuration;
+        return (short) (Entropy.getInstance().settings.baseEventDuration*1.5);
     }
 }

--- a/src/main/java/me/juancarloscp52/entropy/mixin/GameRendererMixin.java
+++ b/src/main/java/me/juancarloscp52/entropy/mixin/GameRendererMixin.java
@@ -87,6 +87,11 @@ public class GameRendererMixin {
         EntropyClient.getInstance().renderShaders(tickDelta);
     }
 
+    @Inject(method = "render", at = @At(value = "TAIL"))
+    public void renderBlackWhiteShader(float tickDelta, long startTime, boolean tick, CallbackInfo ci) {
+        EntropyClient.getInstance().renderBlackAndWhite(tickDelta);
+    }
+
     @Inject(method = "renderWorld", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/Camera;update(Lnet/minecraft/world/BlockView;Lnet/minecraft/entity/Entity;ZZF)V", shift = At.Shift.AFTER))
     private void rollCamera(float tickDelta, long limitTime, MatrixStack matrices, CallbackInfo ci) {
         if(Variables.cameraRoll != 0f)

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -145,6 +145,7 @@
   "entropy.events.StutteringEvent": "Gestotter",
   "entropy.events.ForceHorseRidingEvent": "Es ist Zeit zum Pferdereiten!",
   "entropy.events.JumpscareEvent": "Jumpscare",
+  "entropy.events.BlackAndWhiteEvent": "1950er",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy-Fehler",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -145,6 +145,7 @@
   "entropy.events.StutteringEvent": "Gestotter",
   "entropy.events.ForceHorseRidingEvent": "Es ist Zeit zum Pferdereiten!",
   "entropy.events.JumpscareEvent": "Jumpscare",
+  "entropy.events.BlackAndWhiteEvent": "1950er",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy-Fehler",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -145,6 +145,7 @@
   "entropy.events.StutteringEvent": "Gestotter",
   "entropy.events.ForceHorseRidingEvent": "Es ist Zeit zum Pferdereiten!",
   "entropy.events.JumpscareEvent": "Jumpscare",
+  "entropy.events.BlackAndWhiteEvent": "1950er",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy-Fehler",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -146,6 +146,7 @@
   "entropy.events.ForceHorseRidingEvent": "It's Horse Riding Time!",
   "entropy.events.JumpscareEvent": "Jumpscare",
   "entropy.events.RollingCameraEvent": "Rolling Camera",
+  "entropy.events.BlackAndWhiteEvent": "1950s",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Error",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -146,6 +146,7 @@
   "entropy.events.ForceHorseRidingEvent": "¡Hora de montar a caballo!",
   "entropy.events.JumpscareEvent": "Susto!",
   "entropy.events.RollingCameraEvent": "La cámara da vueltas",
+  "entropy.events.BlackAndWhiteEvent": "Los 50s",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy error",

--- a/src/main/resources/assets/entropy/shaders/post/black_and_white.json
+++ b/src/main/resources/assets/entropy/shaders/post/black_and_white.json
@@ -1,0 +1,23 @@
+{
+    "targets": [
+        "swap"
+    ],
+    "passes": [
+        {
+            "name": "color_convolve",
+            "intarget": "minecraft:main",
+            "outtarget": "swap",
+            "uniforms": [
+                {
+                    "name": "Saturation",
+                    "values": [ 0.0 ]
+                }
+            ]
+        },
+        {
+            "name": "blit",
+            "intarget": "swap",
+            "outtarget": "minecraft:main"
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds an event which turns on a shader that makes everything appear black and white. This also applies to screens, so you won't be able to see colors in your inventory for example. [Without the effect](https://i.imgur.com/NTAFeqo.png) and [with the effect](https://i.imgur.com/O5SCnr8.png) (note that the hotbar is also black and white).