### PR TITLE
Add a command to manually run an event

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/Entropy.java
+++ b/src/main/java/me/juancarloscp52/entropy/Entropy.java
@@ -131,6 +131,14 @@ public class Entropy implements ModInitializer {
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
             dispatcher.register(LiteralArgumentBuilder.<ServerCommandSource>literal("entropy")
                     .requires(source -> source.hasPermissionLevel(3))
+                    .then(CommandManager.literal("clearPastEvents")
+                            .executes(source -> {
+                                ServerEventHandler eventHandler = Entropy.getInstance().eventHandler;
+
+                                eventHandler.currentEvents.removeIf(event -> event.hasEnded());
+                                PlayerLookup.all(eventHandler.server).forEach(player -> ServerPlayNetworking.send(player, NetworkingConstants.REMOVE_ENDED, PacketByteBufs.create()));
+                                return 0;
+                            }))
                     .then(CommandManager.literal("run")
                             .then(CommandManager.argument("event", StringArgumentType.word())
                                     .suggests((context, builder) -> CommandSource.suggestMatching(EventRegistry.entropyEvents.keySet(), builder))

--- a/src/main/java/me/juancarloscp52/entropy/Entropy.java
+++ b/src/main/java/me/juancarloscp52/entropy/Entropy.java
@@ -18,10 +18,15 @@
 package me.juancarloscp52.entropy;
 
 import com.google.gson.Gson;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+
 import me.juancarloscp52.entropy.events.Event;
 import me.juancarloscp52.entropy.events.EventRegistry;
 import me.juancarloscp52.entropy.server.ServerEventHandler;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
@@ -29,7 +34,12 @@ import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.suggestion.SuggestionProviders;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -117,6 +127,27 @@ public class Entropy implements ModInitializer {
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> {
             if (eventHandler != null)
                 eventHandler.endChaos();
+        });
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
+            dispatcher.register(LiteralArgumentBuilder.<ServerCommandSource>literal("entropy")
+                    .requires(source -> source.hasPermissionLevel(3))
+                    .then(CommandManager.literal("run")
+                            .then(CommandManager.argument("event", StringArgumentType.word())
+                                    .suggests((context, builder) -> CommandSource.suggestMatching(EventRegistry.entropyEvents.keySet(), builder))
+                                    .executes(source -> {
+                                        ServerEventHandler eventHandler = Entropy.getInstance().eventHandler;
+
+                                        if(eventHandler != null) {
+                                            String eventId = source.getArgument("event", String.class);
+
+                                            if(eventHandler.runEvent(EventRegistry.get(eventId)))
+                                                Entropy.LOGGER.warn("New event run via command: " + EventRegistry.getTranslationKey(eventId));
+                                            else
+                                                throw new CommandException(Text.translatable("entropy.command.unknownEvent", eventId));
+                                        }
+
+                                        return 0;
+                                    }))));
         });
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/NetworkingConstants.java
+++ b/src/main/java/me/juancarloscp52/entropy/NetworkingConstants.java
@@ -24,6 +24,7 @@ public class NetworkingConstants {
     public static final Identifier JOIN_CONFIRM = new Identifier("entropy", "join-confirm");
     public static final Identifier JOIN_SYNC = new Identifier("entropy", "join-sync");
     public static final Identifier REMOVE_FIRST = new Identifier("entropy", "remove-first");
+    public static final Identifier REMOVE_ENDED = new Identifier("entropy", "remove-ended");
     public static final Identifier ADD_EVENT = new Identifier("entropy", "add-event");
     public static final Identifier END_EVENT = new Identifier("entropy", "end-event");
     public static final Identifier TICK = new Identifier("entropy", "tick");

--- a/src/main/java/me/juancarloscp52/entropy/client/EntropyClient.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/EntropyClient.java
@@ -113,6 +113,15 @@ public class EntropyClient implements ClientModInitializer {
             });
         });
 
+        ClientPlayNetworking.registerGlobalReceiver(NetworkingConstants.REMOVE_ENDED, (client, handler, buf, responseSender) -> {
+            if (clientEventHandler == null)
+                return;
+            client.execute(() -> {
+                if(clientEventHandler.currentEvents.size() != 0)
+                    clientEventHandler.currentEvents.removeIf(event -> event.hasEnded());
+            });
+        });
+
         ClientPlayNetworking.registerGlobalReceiver(NetworkingConstants.ADD_EVENT, (client, handler, buf, responseSender) -> {
             if (clientEventHandler == null)
                 return;

--- a/src/main/java/me/juancarloscp52/entropy/server/ServerEventHandler.java
+++ b/src/main/java/me/juancarloscp52/entropy/server/ServerEventHandler.java
@@ -93,13 +93,7 @@ public class ServerEventHandler {
                 } else
                     event = getRandomEvent(currentEvents);
 
-                if(event != null) {
-                    // Start the event and add it to the list.
-                    event.init();
-                    currentEvents.add(event);
-    
-                    sendEventToPlayers(event);
-                }
+                runEvent(event);
                 if (settings.integrations)
                     voting.newPoll();
 
@@ -126,6 +120,19 @@ public class ServerEventHandler {
 
 
         eventCountDown--;
+    }
+    
+    public boolean runEvent(Event event) {
+        if(event != null) {
+            // Start the event and add it to the list.
+            event.init();
+            currentEvents.add(event);
+
+            sendEventToPlayers(event);
+            return true;
+        }
+        
+        return false;
     }
 
     private void sendEventToPlayers(Event event) {

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "1950er",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",
   "entropy.errorScreen.title": "Entropy-Fehler",
   "entropy.voting.total": "Stimmen insgesamt: %d",
   "entropy.voting.randomEvent": "Zufälliges Ereignis",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "1950er",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",
   "entropy.errorScreen.title": "Entropy-Fehler",
   "entropy.voting.total": "Stimmen insgesamt: %d",
   "entropy.voting.randomEvent": "Zufälliges Ereignis",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "1950er",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",
   "entropy.errorScreen.title": "Entropy-Fehler",
   "entropy.voting.total": "Stimmen insgesamt: %d",
   "entropy.voting.randomEvent": "Zufälliges Ereignis",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "1950s",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Unknown event: %s",
   "entropy.errorScreen.title": "Entropy Error",
   "entropy.voting.total": "Total Votes: %d",
   "entropy.voting.randomEvent": "Random Event",

--- a/src/main/resources/assets/entropy/lang/es_ar.json
+++ b/src/main/resources/assets/entropy/lang/es_ar.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "Los 50s",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Evento desconocido: %s",
   "entropy.errorScreen.title": "Entropy error",
   "entropy.voting.total": "Votos totales: %d",
   "entropy.voting.randomEvent": "Evento aleatorio",

--- a/src/main/resources/assets/entropy/lang/es_cl.json
+++ b/src/main/resources/assets/entropy/lang/es_cl.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "Los 50s",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Evento desconocido: %s",
   "entropy.errorScreen.title": "Entropy error",
   "entropy.voting.total": "Votos totales: %d",
   "entropy.voting.randomEvent": "Evento aleatorio",

--- a/src/main/resources/assets/entropy/lang/es_ec.json
+++ b/src/main/resources/assets/entropy/lang/es_ec.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "Los 50s",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Evento desconocido: %s",
   "entropy.errorScreen.title": "Entropy error",
   "entropy.voting.total": "Votos totales: %d",
   "entropy.voting.randomEvent": "Evento aleatorio",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "Los 50s",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Evento desconocido: %s",
   "entropy.errorScreen.title": "Entropy error",
   "entropy.voting.total": "Votos totales: %d",
   "entropy.voting.randomEvent": "Evento aleatorio",

--- a/src/main/resources/assets/entropy/lang/es_mx.json
+++ b/src/main/resources/assets/entropy/lang/es_mx.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "Los 50s",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Evento desconocido: %s",
   "entropy.errorScreen.title": "Entropy error",
   "entropy.voting.total": "Votos totales: %d",
   "entropy.voting.randomEvent": "Evento aleatorio",

--- a/src/main/resources/assets/entropy/lang/es_uy.json
+++ b/src/main/resources/assets/entropy/lang/es_uy.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "Los 50s",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Evento desconocido: %s",
   "entropy.errorScreen.title": "Entropy error",
   "entropy.voting.total": "Votos totales: %d",
   "entropy.voting.randomEvent": "Evento aleatorio",

--- a/src/main/resources/assets/entropy/lang/es_ve.json
+++ b/src/main/resources/assets/entropy/lang/es_ve.json
@@ -150,6 +150,7 @@
   "entropy.events.BlackAndWhiteEvent": "Los 50s",
 
   "entropy.title": "Entropy: Chaos Mod",
+  "entropy.command.unknownEvent": "Evento desconocido: %s",
   "entropy.errorScreen.title": "Entropy error",
   "entropy.voting.total": "Votos totales: %d",
   "entropy.voting.randomEvent": "Evento aleatorio",


### PR DESCRIPTION
The command needs operator permission. Any event can be run at any time, even if it is disabled. This is helpful to test events without having to wait for the timer. If an event is run, it will immediately be executed, and its duration is independent of the timer.

I also added a subcommand that removes all events from the display that have ended. This makes it possible to clear the display after having manually run a lot of events, creating room for new ones to properly show up without having to wait for the timer to remove them one by one.