### PR TITLE
Fixes for the stuttering event

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/Entropy.java
+++ b/src/main/java/me/juancarloscp52/entropy/Entropy.java
@@ -20,11 +20,11 @@ package me.juancarloscp52.entropy;
 import com.google.gson.Gson;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import com.mojang.brigadier.suggestion.SuggestionProvider;
 
 import me.juancarloscp52.entropy.events.Event;
 import me.juancarloscp52.entropy.events.EventRegistry;
 import me.juancarloscp52.entropy.server.ServerEventHandler;
+import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -36,7 +36,6 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.CommandSource;
-import net.minecraft.command.suggestion.SuggestionProviders;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
@@ -147,6 +146,11 @@ public class Entropy implements ModInitializer {
 
                                         if(eventHandler != null) {
                                             String eventId = source.getArgument("event", String.class);
+
+                                            // If running on integrated server, prevent running Stuttering event.
+                                            if(FabricLoader.getInstance().getEnvironmentType() != EnvType.SERVER && eventId.equals("StutteringEvent")){
+                                                throw new CommandException(Text.translatable("entropy.command.invalidClientSide", eventId));
+                                            }
 
                                             if(eventHandler.runEvent(EventRegistry.get(eventId)))
                                                 Entropy.LOGGER.warn("New event run via command: " + EventRegistry.getTranslationKey(eventId));

--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -19,6 +19,8 @@ package me.juancarloscp52.entropy.events;
 
 import me.juancarloscp52.entropy.Entropy;
 import me.juancarloscp52.entropy.events.db.*;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
 
 import java.util.*;
 import java.util.function.Supplier;
@@ -208,6 +210,12 @@ public class EventRegistry {
         });
         if(eventKeys.size()>ignoreEventsByType.size())
             eventKeys.removeAll(ignoreEventsByType);
+
+        //Only enable the stuttering event on a dedicated server, because otherwise worldgen will be all wrong.
+        //The MathHelper mixin turning off linear interpolation is only applied on the client, but if this is a singleplayer environment,
+        //the integrated server has the modified MathHelper, too, causing incorrect worldgen.
+        if(FabricLoader.getInstance().getEnvironmentType() != EnvType.SERVER)
+            eventKeys.remove("StutteringEvent");
 
         if(eventKeys.size() == 0) return null;
 

--- a/src/main/java/me/juancarloscp52/entropy/mixin/MathHelperMixin.java
+++ b/src/main/java/me/juancarloscp52/entropy/mixin/MathHelperMixin.java
@@ -27,4 +27,10 @@ public class MathHelperMixin {
         if(Variables.stuttering)
             cir.setReturnValue(start);
     }
+
+    @Inject(method = "lerpAngle", at = @At("HEAD"), cancellable = true)
+    private static void lerpAngle(float start, float end, float delta, CallbackInfoReturnable<Float> cir) {
+        if(Variables.stuttering)
+            cir.setReturnValue(start);
+    }
 }

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -151,6 +151,7 @@
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",
+  "entropy.command.invalidClientSide": "Ereignis %s kann nicht im Einzelspieler ausgeführt werden",
   "entropy.errorScreen.title": "Entropy-Fehler",
   "entropy.voting.total": "Stimmen insgesamt: %d",
   "entropy.voting.randomEvent": "Zufälliges Ereignis",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -151,6 +151,7 @@
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",
+  "entropy.command.invalidClientSide": "Ereignis %s kann nicht im Einzelspieler ausgeführt werden",
   "entropy.errorScreen.title": "Entropy-Fehler",
   "entropy.voting.total": "Stimmen insgesamt: %d",
   "entropy.voting.randomEvent": "Zufälliges Ereignis",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -151,6 +151,7 @@
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",
+  "entropy.command.invalidClientSide": "Ereignis %s kann nicht im Einzelspieler ausgeführt werden",
   "entropy.errorScreen.title": "Entropy-Fehler",
   "entropy.voting.total": "Stimmen insgesamt: %d",
   "entropy.voting.randomEvent": "Zufälliges Ereignis",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -151,6 +151,7 @@
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unknown event: %s",
+  "entropy.command.invalidClientSide": "Event %s cannot be run while on single-player",
   "entropy.errorScreen.title": "Entropy Error",
   "entropy.voting.total": "Total Votes: %d",
   "entropy.voting.randomEvent": "Random Event",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -151,6 +151,7 @@
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Evento desconocido: %s",
+  "entropy.command.invalidClientSide": "El evento %s no se puede ejecutar en modo un jugador.",
   "entropy.errorScreen.title": "Entropy error",
   "entropy.voting.total": "Votos totales: %d",
   "entropy.voting.randomEvent": "Evento aleatorio",


### PR DESCRIPTION
The first fix added is another Inject into MathHelper, which now also covers horses, shulker bullets, wither skulls, and jumping dolphins and foxes.
The second fix is disabling the event in singleplayer, as it leads to [faulty worldgen](https://i.imgur.com/dAtlOCN.png) due to the integrated server using the modified MathHelper for worldgen. MathHelperMixin is only applied on clients, so worldgen on a dedicated server is not affected. I chose this solution over creating mixins for all instances where linear interpolation is used in worldgen, because there are a lot of places it is used and it would quickly overwhelm.

If #87 is merged, it may be beneficial to also prevent running of this event via the command in singleplayer.