### PR TITLE
Twitch vote fix

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/client/integrations/twitch/TwitchIntegrations.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/integrations/twitch/TwitchIntegrations.java
@@ -103,7 +103,7 @@ public class TwitchIntegrations extends ListenerAdapter implements Integrations 
 
     @Override
     public void onMessage(MessageEvent event) {
-        EntropyClient.getInstance().clientEventHandler.votingClient.processVote(event.getMessage(), event.getUser().getUserId().toString());
+        EntropyClient.getInstance().clientEventHandler.votingClient.processVote(event.getMessage(), event.getUser().getLogin());
     }
 
     @Override


### PR DESCRIPTION
I though that event.getUser().getUserId() will return twitch's user id, appears that it returns UUID for connection to IRC server. It will be different everytime you connect to chat. Viewers able to open multiple chat windows and vote multiple times. This PR fixes that.