### PR TITLE
Support German language files in language script

### DIFF
--- a/langGenerator.sh
+++ b/langGenerator.sh
@@ -14,10 +14,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
-
+#!/bin/bash
 cd src/main/resources/assets/entropy/lang
-list=("ar" "cl" "ec" "mx" "uy" "ve")
-for elem in ar cl ec mx uy ve; do
+declare -a spanish=("ar cl ec mx uy ve")
+for elem in $spanish; do
     echo $elem
-  cp es_es.json es_$elem.json
+    cp es_es.json es_$elem.json
+done
+
+declare -a german=("at ch")
+for elem in $german; do
+    echo $elem
+    cp de_de.json de_$elem.json
 done


### PR DESCRIPTION
This PR modifies the previously named `spanishLangGenerator` script to also support German language files `de_at` and `de_ch`. It is renamed to `langGenerator` to reflect that it no longer only generates Spanish files. Additionally, there's a fix to make use of the `list` (now `spanish`) variable and iterate over that array.