### PR TITLE
feat: Add Websocket server and ability to remove displayed events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     include 'com.fasterxml.jackson.core:jackson-annotations:2.10.1'
     include 'com.fasterxml.jackson.core:jackson-core:2.10.1'
 
+    // Websocket Server for Overlay
+    implementation 'org.java-websocket:Java-WebSocket:1.5.3'
+
 }
 
 loom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19.3
 yarn_mappings=1.19.3+build.2
 loader_version=0.14.11
 # Mod Properties
-mod_version=1.11+mc1.19.3
+mod_version=1.11-twitch+mc1.19.3
 maven_group=me.juancarloscp52
 archives_base_name=Entropy
 # Dependencies

--- a/src/main/java/me/juancarloscp52/entropy/client/EntropyIntegrationsSettings.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/EntropyIntegrationsSettings.java
@@ -24,6 +24,9 @@ public class EntropyIntegrationsSettings {
     public String channel = "";
     public boolean sendChatMessages = true;
     public boolean showCurrentPercentage = true;
+
+    public boolean showUpcomingEvents = true;
+
     public String discordToken = "";
     public long discordChannel = -1;
     public String youtubeClientId = "";

--- a/src/main/java/me/juancarloscp52/entropy/client/Screens/EntropyIntegrationsScreen.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/Screens/EntropyIntegrationsScreen.java
@@ -179,11 +179,11 @@ public class EntropyIntegrationsScreen extends Screen {
         });
 
         Text showPollStatusText = Text.translatable("entropy.options.integrations.showPollStatus");
-        showPollStatus = new CheckboxWidget(this.width / 2 - ((textRenderer.getWidth(showPollStatusText) / 2) + 11), 100, 150, 20, showPollStatusText, integrationsSettings.showCurrentPercentage);
+        showPollStatus = new CheckboxWidget(this.width / 2 - ((textRenderer.getWidth(showPollStatusText))+20), 140, 150, 20, showPollStatusText, integrationsSettings.showCurrentPercentage);
         this.addDrawableChild(showPollStatus);
 
         Text showUpcomingEventsText = Text.translatable("entropy.options.integrations.showUpcomingEvents");
-        showUpcomingEvents = new CheckboxWidget(this.width / 2 - ((textRenderer.getWidth(showUpcomingEventsText) / 2) + 11), 120, 150, 20, showUpcomingEventsText, integrationsSettings.showUpcomingEvents);
+        showUpcomingEvents = new CheckboxWidget(this.width / 2 + (20), 140, 150, 20, showUpcomingEventsText, integrationsSettings.showUpcomingEvents);
         this.addDrawableChild(showUpcomingEvents);
 
         Text sendChatMessagesText = Text.translatable("entropy.options.integrations.twitch.sendChatFeedBack");
@@ -222,6 +222,7 @@ public class EntropyIntegrationsScreen extends Screen {
                 tokenTranslatable = Text.translatable("entropy.options.integrations.twitch.OAuthToken");
                 channelTranslatable = Text.translatable("entropy.options.integrations.twitch.channelName");
                 showPollStatus.setY(140);
+                showUpcomingEvents.setY(140);
                 sendChatMessages.setY(165);
                 sendChatMessages.setMessage(Text.translatable("entropy.options.integrations.twitch.sendChatFeedBack"));
             }
@@ -240,6 +241,7 @@ public class EntropyIntegrationsScreen extends Screen {
                 tokenTranslatable = Text.translatable("entropy.options.integrations.discord.token");
                 channelTranslatable = Text.translatable("entropy.options.integrations.discord.channelId");
                 showPollStatus.setY(140);
+                showUpcomingEvents.setY(140);
                 sendChatMessages.setY(165);
             }
             case 3 -> {
@@ -257,6 +259,7 @@ public class EntropyIntegrationsScreen extends Screen {
                 tokenTranslatable = Text.translatable("entropy.options.integrations.youtube.clientId");
                 channelTranslatable = Text.translatable("entropy.options.integrations.youtube.secret");
                 showPollStatus.setY(160);
+                showUpcomingEvents.setY(160);
                 sendChatMessages.setY(185);
                 sendChatMessages.setMessage(Text.translatable("entropy.options.integrations.youtube.sendChatFeedBack"));
             }
@@ -275,6 +278,7 @@ public class EntropyIntegrationsScreen extends Screen {
                 tokenTranslatable = Text.translatable("");
                 channelTranslatable = Text.translatable("");
                 showPollStatus.setY(140);
+                showUpcomingEvents.setY(140);
                 sendChatMessages.setY(165);
             }
         }

--- a/src/main/java/me/juancarloscp52/entropy/client/Screens/EntropyIntegrationsScreen.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/Screens/EntropyIntegrationsScreen.java
@@ -68,6 +68,7 @@ public class EntropyIntegrationsScreen extends Screen {
     Text channelTranslatable;
     CheckboxWidget sendChatMessages;
     CheckboxWidget showPollStatus;
+    CheckboxWidget showUpcomingEvents;
 
     ButtonWidget done;
 
@@ -181,6 +182,10 @@ public class EntropyIntegrationsScreen extends Screen {
         showPollStatus = new CheckboxWidget(this.width / 2 - ((textRenderer.getWidth(showPollStatusText) / 2) + 11), 100, 150, 20, showPollStatusText, integrationsSettings.showCurrentPercentage);
         this.addDrawableChild(showPollStatus);
 
+        Text showUpcomingEventsText = Text.translatable("entropy.options.integrations.showUpcomingEvents");
+        showUpcomingEvents = new CheckboxWidget(this.width / 2 - ((textRenderer.getWidth(showUpcomingEventsText) / 2) + 11), 120, 150, 20, showUpcomingEventsText, integrationsSettings.showUpcomingEvents);
+        this.addDrawableChild(showUpcomingEvents);
+
         Text sendChatMessagesText = Text.translatable("entropy.options.integrations.twitch.sendChatFeedBack");
         sendChatMessages = new CheckboxWidget(this.width / 2 - ((textRenderer.getWidth(sendChatMessagesText) / 2) + 11), 145, 150, 20, sendChatMessagesText, integrationsSettings.sendChatMessages);
         this.addDrawableChild(sendChatMessages);
@@ -207,6 +212,7 @@ public class EntropyIntegrationsScreen extends Screen {
                 twitchToken.setVisible(true);
                 sendChatMessages.visible = true;
                 showPollStatus.visible = true;
+                showUpcomingEvents.visible = true;
                 discordChannel.setVisible(false);
                 discordToken.setVisible(false);
                 youtubeClientId.setVisible(false);
@@ -224,6 +230,7 @@ public class EntropyIntegrationsScreen extends Screen {
                 twitchToken.setVisible(false);
                 sendChatMessages.visible = false;
                 showPollStatus.visible = true;
+                showUpcomingEvents.visible = true;
                 discordChannel.setVisible(true);
                 discordToken.setVisible(true);
                 youtubeClientId.setVisible(false);
@@ -240,6 +247,7 @@ public class EntropyIntegrationsScreen extends Screen {
                 twitchToken.setVisible(false);
                 sendChatMessages.visible = true;
                 showPollStatus.visible = true;
+                showUpcomingEvents.visible = true;
                 discordChannel.setVisible(false);
                 discordToken.setVisible(false);
                 youtubeClientId.setVisible(true);
@@ -257,6 +265,7 @@ public class EntropyIntegrationsScreen extends Screen {
                 twitchToken.setVisible(false);
                 sendChatMessages.visible = false;
                 showPollStatus.visible = false;
+                showUpcomingEvents.visible = false;
                 discordChannel.setVisible(false);
                 discordToken.setVisible(false);
                 youtubeClientId.setVisible(false);
@@ -314,6 +323,7 @@ public class EntropyIntegrationsScreen extends Screen {
 
         integrationsSettings.sendChatMessages = sendChatMessages.isChecked();
         integrationsSettings.showCurrentPercentage = showPollStatus.isChecked();
+        integrationsSettings.showUpcomingEvents = showUpcomingEvents.isChecked();
 
         EntropyClient.getInstance().saveSettings();
         Entropy.getInstance().saveSettings();

--- a/src/main/java/me/juancarloscp52/entropy/client/VotingClient.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/VotingClient.java
@@ -179,7 +179,8 @@ public class VotingClient {
         buf.writeIntArray(this.votes);
         votes = new int[4];
         ClientPlayNetworking.send(NetworkingConstants.POLL_STATUS, buf);
-        this.overlayServer.updateVote(voteID,events,totalVotes);
+        if(EntropyClient.getInstance().integrationsSettings.showCurrentPercentage)
+            this.overlayServer.updateVote(voteID,events,totalVotes);
 
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/client/VotingClient.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/VotingClient.java
@@ -183,9 +183,7 @@ public class VotingClient {
         buf.writeIntArray(this.votes);
         votes = new int[4];
         ClientPlayNetworking.send(NetworkingConstants.POLL_STATUS, buf);
-        if(EntropyClient.getInstance().integrationsSettings.showCurrentPercentage)
-            this.overlayServer.updateVote(voteID,events,totalVotes);
-
+        this.overlayServer.updateVote(voteID,events,totalVotes);
     }
 
     public int getColor() {

--- a/src/main/java/me/juancarloscp52/entropy/client/VotingClient.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/VotingClient.java
@@ -103,7 +103,11 @@ public class VotingClient {
 
     public void newPoll(int voteID, int size, List<String> events) {
         voteMap.clear();
-        this.overlayServer.onVoteEnd();
+        if(firstVote){
+            firstVote=false;
+        } else {
+            this.overlayServer.onVoteEnd();
+        }
         if (this.size == size) {
             this.voteID = voteID;
             this.events = events;

--- a/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayMessage.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayMessage.java
@@ -1,0 +1,4 @@
+package me.juancarloscp52.entropy.client.websocket;
+
+public record OverlayMessage(String request, int totalVotes, String votingMode, OverlayVoteOption[] voteOptions){
+}

--- a/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayServer.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayServer.java
@@ -59,12 +59,13 @@ public class OverlayServer {
 
 
     public void updateVote(int voteID, List<String> events, int[] votes) {
+        boolean showVotes = EntropyClient.getInstance().integrationsSettings.showCurrentPercentage;
         int altOffset = voteID % 2 == 0 ? 5 : 1;
         if(EntropyClient.getInstance().integrationsSettings.integrationType==2)
             altOffset=1;
         List<OverlayVoteOption> options=new ArrayList<>();
         for (int i = 0; i < events.size(); i++) {
-            options.add(new OverlayVoteOption(I18n.translate(events.get(i)),new String[]{Integer.toString(i+altOffset)},votes[i]));
+            options.add(new OverlayVoteOption(I18n.translate(events.get(i)),new String[]{Integer.toString(i+altOffset)}, showVotes ? votes[i]:0));
         }
         this.overlayWebsocket.UpdateVoting(options);
 

--- a/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayServer.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayServer.java
@@ -1,0 +1,77 @@
+package me.juancarloscp52.entropy.client.websocket;
+
+import me.juancarloscp52.entropy.client.EntropyClient;
+import net.minecraft.client.resource.language.I18n;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class OverlayServer {
+
+    public OverlayWebsocket overlayWebsocket;
+    private ExecutorService botExecutor;
+
+    public OverlayServer() {
+        this.start();
+    }
+
+    public void start() {
+        this.overlayWebsocket = new OverlayWebsocket(new InetSocketAddress("localhost",9091));
+
+        botExecutor = Executors.newCachedThreadPool();
+        botExecutor.execute(() -> {
+            try {
+                this.overlayWebsocket.start();
+            } catch (Exception e) {
+                EntropyClient.LOGGER.error("Exception while starting bot: " + e.getMessage());
+                e.printStackTrace();
+            }
+        });
+    }
+
+    public void stop() {
+        try {
+            this.overlayWebsocket.stop();
+        } catch (InterruptedException e) {
+            EntropyClient.LOGGER.error("Exception while stopping bot: " + e.getMessage());
+            e.printStackTrace();
+        }
+        botExecutor.shutdown();
+    }
+
+    public void onNewVote(int voteID, List<String> events) {
+
+        int altOffset = voteID % 2 == 0 ? 5 : 1;
+
+        if(EntropyClient.getInstance().integrationsSettings.integrationType==2)
+            altOffset=1;
+
+        List<OverlayVoteOption> options=new ArrayList<>();
+
+        for (int i = 0; i < events.size(); i++) {
+            options.add(new OverlayVoteOption(I18n.translate(events.get(i)),new String[]{Integer.toString(i+altOffset)},0));
+        }
+        this.overlayWebsocket.NewVoting(options);
+    }
+
+
+    public void updateVote(int voteID, List<String> events, int[] votes) {
+        int altOffset = voteID % 2 == 0 ? 5 : 1;
+        if(EntropyClient.getInstance().integrationsSettings.integrationType==2)
+            altOffset=1;
+        List<OverlayVoteOption> options=new ArrayList<>();
+        for (int i = 0; i < events.size(); i++) {
+            options.add(new OverlayVoteOption(I18n.translate(events.get(i)),new String[]{Integer.toString(i+altOffset)},votes[i]));
+        }
+        this.overlayWebsocket.UpdateVoting(options);
+
+    }
+    public void onVoteEnd() {
+        this.overlayWebsocket.EndVoting();
+    }
+
+
+}

--- a/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayVoteOption.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayVoteOption.java
@@ -1,0 +1,4 @@
+package me.juancarloscp52.entropy.client.websocket;
+
+public record OverlayVoteOption(String label,String[] matches,int value) {
+}

--- a/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayWebsocket.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayWebsocket.java
@@ -3,7 +3,6 @@ package me.juancarloscp52.entropy.client.websocket;
 import com.google.gson.Gson;
 import me.juancarloscp52.entropy.Entropy;
 import me.juancarloscp52.entropy.EntropySettings;
-import me.juancarloscp52.entropy.client.EntropyClient;
 import org.java_websocket.WebSocket;
 import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.server.WebSocketServer;
@@ -17,6 +16,7 @@ public class OverlayWebsocket extends WebSocketServer {
     public Gson gson;
     public OverlayWebsocket(InetSocketAddress address) {
         super(address);
+        this.setReuseAddr(true);
         gson=new Gson();
     }
     public void EndVoting() {

--- a/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayWebsocket.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/websocket/OverlayWebsocket.java
@@ -1,0 +1,77 @@
+package me.juancarloscp52.entropy.client.websocket;
+
+import com.google.gson.Gson;
+import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.EntropySettings;
+import me.juancarloscp52.entropy.client.EntropyClient;
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+public class OverlayWebsocket extends WebSocketServer {
+
+    public Gson gson;
+    public OverlayWebsocket(InetSocketAddress address) {
+        super(address);
+        gson=new Gson();
+    }
+    public void EndVoting() {
+        Request("END", new ArrayList<>());
+    }
+
+    public void NewVoting(List<OverlayVoteOption> options) {
+        Request("CREATE",options);
+    }
+
+    public void UpdateVoting(List<OverlayVoteOption> options) {
+        Request("UPDATE", options);
+    }
+
+    public void Message(String message) {
+        // Note, Chaos Mod V websocket protocol does not currently code for
+        // a string message. This is therefore deliberately left blank for now.
+    }
+
+
+    private void Request(String request, List<OverlayVoteOption> voteOptions) {
+        int totalVotes = 0;
+        for (OverlayVoteOption option: voteOptions) {
+            totalVotes+=option.value();
+        }
+        OverlayVoteOption[] options=new OverlayVoteOption[voteOptions.size()];
+        voteOptions.toArray(options);
+        OverlayMessage msg=new OverlayMessage(request,totalVotes, Entropy.getInstance().settings.votingMode == EntropySettings.VotingMode.MAJORITY ? "MAJORITY" : "PERCENTAGE",options);
+        String broadcastString = gson.toJson(msg);
+        Entropy.LOGGER.debug("Broadcasting: "+broadcastString);
+        this.broadcast(broadcastString);
+    }
+
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {
+
+    }
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, String message) {
+
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+
+    }
+
+    @Override
+    public void onStart() {
+
+    }
+}

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -205,6 +205,7 @@
   "entropy.options.integrations.discord.help": "Discord Integrations enables users of a server to vote what will be the next event. A message will appear on the selected channel with the different available options and users can vote by reacting to the message with the given numbers. To enable discord integration, you need to create a Discord bot, join it to your server and copy the bot token here. Also, you must write here the Channel ID (its a number). Alternatively, once the discord bot has joined the server and a minecraft world with entropy is open, you can write \"!entropy join\" on the discord server channel.",
   "entropy.options.integrations.youtube.help": "YouTube Integrations enables the chat to vote what will be the next event during streams. Chat will be able to vote writing numbers in chat that correspond to an event. The different available events for the poll will be shown on screen with their corresponding number. In order to use this feature, the streamer needs to create an API project in Google Cloud Console, create OAuth 2.0 Client ID credential, insert a client id and secret, and authorize the mod to interact with youtube.",
   "entropy.options.integrations.showPollStatus": "Show poll status on screen",
+  "entropy.options.integrations.showUpcomingEvents": "Show upcoming events on screen",
   "entropy.options.checkAllEvents": "Enable All",
   "entropy.options.uncheckAllEvents": "Disable All",
   "entropy.options.filterEvents": "Filter Events",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -205,7 +205,7 @@
   "entropy.options.integrations.discord.help": "Discord Integrations enables users of a server to vote what will be the next event. A message will appear on the selected channel with the different available options and users can vote by reacting to the message with the given numbers. To enable discord integration, you need to create a Discord bot, join it to your server and copy the bot token here. Also, you must write here the Channel ID (its a number). Alternatively, once the discord bot has joined the server and a minecraft world with entropy is open, you can write \"!entropy join\" on the discord server channel.",
   "entropy.options.integrations.youtube.help": "YouTube Integrations enables the chat to vote what will be the next event during streams. Chat will be able to vote writing numbers in chat that correspond to an event. The different available events for the poll will be shown on screen with their corresponding number. In order to use this feature, the streamer needs to create an API project in Google Cloud Console, create OAuth 2.0 Client ID credential, insert a client id and secret, and authorize the mod to interact with youtube.",
   "entropy.options.integrations.showPollStatus": "Show poll status on screen",
-  "entropy.options.integrations.showUpcomingEvents": "Show voting options on screen",
+  "entropy.options.integrations.showUpcomingEvents": "Show voting options on Minecraft",
   "entropy.options.checkAllEvents": "Enable All",
   "entropy.options.uncheckAllEvents": "Disable All",
   "entropy.options.filterEvents": "Filter Events",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -205,7 +205,7 @@
   "entropy.options.integrations.discord.help": "Discord Integrations enables users of a server to vote what will be the next event. A message will appear on the selected channel with the different available options and users can vote by reacting to the message with the given numbers. To enable discord integration, you need to create a Discord bot, join it to your server and copy the bot token here. Also, you must write here the Channel ID (its a number). Alternatively, once the discord bot has joined the server and a minecraft world with entropy is open, you can write \"!entropy join\" on the discord server channel.",
   "entropy.options.integrations.youtube.help": "YouTube Integrations enables the chat to vote what will be the next event during streams. Chat will be able to vote writing numbers in chat that correspond to an event. The different available events for the poll will be shown on screen with their corresponding number. In order to use this feature, the streamer needs to create an API project in Google Cloud Console, create OAuth 2.0 Client ID credential, insert a client id and secret, and authorize the mod to interact with youtube.",
   "entropy.options.integrations.showPollStatus": "Show poll status on screen",
-  "entropy.options.integrations.showUpcomingEvents": "Show upcoming events on screen",
+  "entropy.options.integrations.showUpcomingEvents": "Show voting options on screen",
   "entropy.options.checkAllEvents": "Enable All",
   "entropy.options.uncheckAllEvents": "Disable All",
   "entropy.options.filterEvents": "Filter Events",

--- a/src/main/resources/assets/entropy/lang/es_ar.json
+++ b/src/main/resources/assets/entropy/lang/es_ar.json
@@ -204,6 +204,7 @@
   "entropy.options.integrations.twitch.help": "La integración con Twitch permite que el chat vote durante el directo cual será el próximo evento. Los usuarios podrán escribir numeros en el chat que representarán un evento especifico. Los diferentes eventos por los que se pueden votar se mostrarán en pantalla con su correspondiente número durante la encuesta. Para usar esta función, el streamer debe poner un OAuth Token con permisos de \"Chat Login\" y el nombre del canal de Twitch.",
   "entropy.options.integrations.discord.help": "La integración con discord permite a los usuarios de un servidor de discord votar cual será el siguiente evento en tu partida. Un mensaje con las diferentes opciones aparecerá en el canal de discord seleccionado, los usuarios podrán votar reaccionando a dicho mensaje. Para habilitar la integración con discord, deberás crear un bot de discord, hacer que se una a tu servidor y copiar el token del BOT en esta pantalla. También tendras que escribir aquí la ID del canal donde se publicarán los mensajes. Tambien puedes usar el comando \"!entropy join\" en el canal a unirse.",
   "entropy.options.integrations.showPollStatus": "Mostrar estado de la encuesta en pantalla",
+  "entropy.options.integrations.showUpcomingEvents": "Mostrar opciones de voto en Minecraft",
   "entropy.options.checkAllEvents": "Seleccionar todos",
   "entropy.options.uncheckAllEvents": "Deseleccionar todos",
   "entropy.options.filterEvents": "Filtrar eventos",

--- a/src/main/resources/assets/entropy/lang/es_cl.json
+++ b/src/main/resources/assets/entropy/lang/es_cl.json
@@ -204,6 +204,7 @@
   "entropy.options.integrations.twitch.help": "La integración con Twitch permite que el chat vote durante el directo cual será el próximo evento. Los usuarios podrán escribir numeros en el chat que representarán un evento especifico. Los diferentes eventos por los que se pueden votar se mostrarán en pantalla con su correspondiente número durante la encuesta. Para usar esta función, el streamer debe poner un OAuth Token con permisos de \"Chat Login\" y el nombre del canal de Twitch.",
   "entropy.options.integrations.discord.help": "La integración con discord permite a los usuarios de un servidor de discord votar cual será el siguiente evento en tu partida. Un mensaje con las diferentes opciones aparecerá en el canal de discord seleccionado, los usuarios podrán votar reaccionando a dicho mensaje. Para habilitar la integración con discord, deberás crear un bot de discord, hacer que se una a tu servidor y copiar el token del BOT en esta pantalla. También tendras que escribir aquí la ID del canal donde se publicarán los mensajes. Tambien puedes usar el comando \"!entropy join\" en el canal a unirse.",
   "entropy.options.integrations.showPollStatus": "Mostrar estado de la encuesta en pantalla",
+  "entropy.options.integrations.showUpcomingEvents": "Mostrar opciones de voto en Minecraft",
   "entropy.options.checkAllEvents": "Seleccionar todos",
   "entropy.options.uncheckAllEvents": "Deseleccionar todos",
   "entropy.options.filterEvents": "Filtrar eventos",

--- a/src/main/resources/assets/entropy/lang/es_ec.json
+++ b/src/main/resources/assets/entropy/lang/es_ec.json
@@ -204,6 +204,7 @@
   "entropy.options.integrations.twitch.help": "La integración con Twitch permite que el chat vote durante el directo cual será el próximo evento. Los usuarios podrán escribir numeros en el chat que representarán un evento especifico. Los diferentes eventos por los que se pueden votar se mostrarán en pantalla con su correspondiente número durante la encuesta. Para usar esta función, el streamer debe poner un OAuth Token con permisos de \"Chat Login\" y el nombre del canal de Twitch.",
   "entropy.options.integrations.discord.help": "La integración con discord permite a los usuarios de un servidor de discord votar cual será el siguiente evento en tu partida. Un mensaje con las diferentes opciones aparecerá en el canal de discord seleccionado, los usuarios podrán votar reaccionando a dicho mensaje. Para habilitar la integración con discord, deberás crear un bot de discord, hacer que se una a tu servidor y copiar el token del BOT en esta pantalla. También tendras que escribir aquí la ID del canal donde se publicarán los mensajes. Tambien puedes usar el comando \"!entropy join\" en el canal a unirse.",
   "entropy.options.integrations.showPollStatus": "Mostrar estado de la encuesta en pantalla",
+  "entropy.options.integrations.showUpcomingEvents": "Mostrar opciones de voto en Minecraft",
   "entropy.options.checkAllEvents": "Seleccionar todos",
   "entropy.options.uncheckAllEvents": "Deseleccionar todos",
   "entropy.options.filterEvents": "Filtrar eventos",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -204,6 +204,7 @@
   "entropy.options.integrations.twitch.help": "La integración con Twitch permite que el chat vote durante el directo cual será el próximo evento. Los usuarios podrán escribir numeros en el chat que representarán un evento especifico. Los diferentes eventos por los que se pueden votar se mostrarán en pantalla con su correspondiente número durante la encuesta. Para usar esta función, el streamer debe poner un OAuth Token con permisos de \"Chat Login\" y el nombre del canal de Twitch.",
   "entropy.options.integrations.discord.help": "La integración con discord permite a los usuarios de un servidor de discord votar cual será el siguiente evento en tu partida. Un mensaje con las diferentes opciones aparecerá en el canal de discord seleccionado, los usuarios podrán votar reaccionando a dicho mensaje. Para habilitar la integración con discord, deberás crear un bot de discord, hacer que se una a tu servidor y copiar el token del BOT en esta pantalla. También tendras que escribir aquí la ID del canal donde se publicarán los mensajes. Tambien puedes usar el comando \"!entropy join\" en el canal a unirse.",
   "entropy.options.integrations.showPollStatus": "Mostrar estado de la encuesta en pantalla",
+  "entropy.options.integrations.showUpcomingEvents": "Mostrar opciones de voto en Minecraft",
   "entropy.options.checkAllEvents": "Seleccionar todos",
   "entropy.options.uncheckAllEvents": "Deseleccionar todos",
   "entropy.options.filterEvents": "Filtrar eventos",

--- a/src/main/resources/assets/entropy/lang/es_mx.json
+++ b/src/main/resources/assets/entropy/lang/es_mx.json
@@ -204,6 +204,7 @@
   "entropy.options.integrations.twitch.help": "La integración con Twitch permite que el chat vote durante el directo cual será el próximo evento. Los usuarios podrán escribir numeros en el chat que representarán un evento especifico. Los diferentes eventos por los que se pueden votar se mostrarán en pantalla con su correspondiente número durante la encuesta. Para usar esta función, el streamer debe poner un OAuth Token con permisos de \"Chat Login\" y el nombre del canal de Twitch.",
   "entropy.options.integrations.discord.help": "La integración con discord permite a los usuarios de un servidor de discord votar cual será el siguiente evento en tu partida. Un mensaje con las diferentes opciones aparecerá en el canal de discord seleccionado, los usuarios podrán votar reaccionando a dicho mensaje. Para habilitar la integración con discord, deberás crear un bot de discord, hacer que se una a tu servidor y copiar el token del BOT en esta pantalla. También tendras que escribir aquí la ID del canal donde se publicarán los mensajes. Tambien puedes usar el comando \"!entropy join\" en el canal a unirse.",
   "entropy.options.integrations.showPollStatus": "Mostrar estado de la encuesta en pantalla",
+  "entropy.options.integrations.showUpcomingEvents": "Mostrar opciones de voto en Minecraft",
   "entropy.options.checkAllEvents": "Seleccionar todos",
   "entropy.options.uncheckAllEvents": "Deseleccionar todos",
   "entropy.options.filterEvents": "Filtrar eventos",

--- a/src/main/resources/assets/entropy/lang/es_uy.json
+++ b/src/main/resources/assets/entropy/lang/es_uy.json
@@ -204,6 +204,7 @@
   "entropy.options.integrations.twitch.help": "La integración con Twitch permite que el chat vote durante el directo cual será el próximo evento. Los usuarios podrán escribir numeros en el chat que representarán un evento especifico. Los diferentes eventos por los que se pueden votar se mostrarán en pantalla con su correspondiente número durante la encuesta. Para usar esta función, el streamer debe poner un OAuth Token con permisos de \"Chat Login\" y el nombre del canal de Twitch.",
   "entropy.options.integrations.discord.help": "La integración con discord permite a los usuarios de un servidor de discord votar cual será el siguiente evento en tu partida. Un mensaje con las diferentes opciones aparecerá en el canal de discord seleccionado, los usuarios podrán votar reaccionando a dicho mensaje. Para habilitar la integración con discord, deberás crear un bot de discord, hacer que se una a tu servidor y copiar el token del BOT en esta pantalla. También tendras que escribir aquí la ID del canal donde se publicarán los mensajes. Tambien puedes usar el comando \"!entropy join\" en el canal a unirse.",
   "entropy.options.integrations.showPollStatus": "Mostrar estado de la encuesta en pantalla",
+  "entropy.options.integrations.showUpcomingEvents": "Mostrar opciones de voto en Minecraft",
   "entropy.options.checkAllEvents": "Seleccionar todos",
   "entropy.options.uncheckAllEvents": "Deseleccionar todos",
   "entropy.options.filterEvents": "Filtrar eventos",

--- a/src/main/resources/assets/entropy/lang/es_ve.json
+++ b/src/main/resources/assets/entropy/lang/es_ve.json
@@ -204,6 +204,7 @@
   "entropy.options.integrations.twitch.help": "La integración con Twitch permite que el chat vote durante el directo cual será el próximo evento. Los usuarios podrán escribir numeros en el chat que representarán un evento especifico. Los diferentes eventos por los que se pueden votar se mostrarán en pantalla con su correspondiente número durante la encuesta. Para usar esta función, el streamer debe poner un OAuth Token con permisos de \"Chat Login\" y el nombre del canal de Twitch.",
   "entropy.options.integrations.discord.help": "La integración con discord permite a los usuarios de un servidor de discord votar cual será el siguiente evento en tu partida. Un mensaje con las diferentes opciones aparecerá en el canal de discord seleccionado, los usuarios podrán votar reaccionando a dicho mensaje. Para habilitar la integración con discord, deberás crear un bot de discord, hacer que se una a tu servidor y copiar el token del BOT en esta pantalla. También tendras que escribir aquí la ID del canal donde se publicarán los mensajes. Tambien puedes usar el comando \"!entropy join\" en el canal a unirse.",
   "entropy.options.integrations.showPollStatus": "Mostrar estado de la encuesta en pantalla",
+  "entropy.options.integrations.showUpcomingEvents": "Mostrar opciones de voto en Minecraft",
   "entropy.options.checkAllEvents": "Seleccionar todos",
   "entropy.options.uncheckAllEvents": "Deseleccionar todos",
   "entropy.options.filterEvents": "Filtrar eventos",


### PR DESCRIPTION
This allows any of the ChaosModV web socket clients to be used with the mod, so an OBS browser-source can be used to display the upcoming events to chat, rather then displayed to the player/streamer.

An example can be found here: https://www.twitch.tv/videos/1753852677

Note that this does not include the HTML file , only the web socket server to enable a HTML file to be used. I used the ChaosModV format so any streamers who have one for that, don't have to change anything. The default one from gta-chaos-mod/ChaosModV also works