### PR TITLE
fix: Add websocket library into build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 
     // Websocket Server for Overlay
     implementation 'org.java-websocket:Java-WebSocket:1.5.3'
+    include 'org.java-websocket:Java-WebSocket:1.5.3'
 
 }
 


### PR DESCRIPTION
I am so sorry, it seems I forgot to add the library to be included when the jar is built fully