### PR TITLE
Make StutteringEvent apply to newly added lerp method as well

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/mixin/MathHelperMixin.java
+++ b/src/main/java/me/juancarloscp52/entropy/mixin/MathHelperMixin.java
@@ -9,6 +9,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(MathHelper.class)
 public class MathHelperMixin {
+    @Inject(method = "Lnet/minecraft/util/math/MathHelper;lerp(FII)I", at = @At("HEAD"), cancellable = true)
+    private static void lerp(float delta, int start, int end, CallbackInfoReturnable<Integer> cir) {
+        if(Variables.stuttering)
+            cir.setReturnValue(start);
+    }
+
     @Inject(method = "Lnet/minecraft/util/math/MathHelper;lerp(FFF)F", at = @At("HEAD"), cancellable = true)
     private static void lerp(float delta, float start, float end, CallbackInfoReturnable<Float> cir) {
         if(Variables.stuttering)


### PR DESCRIPTION
The new lerp method takes a float and two integers, and returns an integer. It was added in 1.19.4 and is used by display entities. Adding it to the MathHelper mixin means that display entities will now also be affected by the stuttering event.