### PR TITLE
Add a base event to handle multiple events at once + two new events making use of it

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/client/ClientEventHandler.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/ClientEventHandler.java
@@ -106,9 +106,11 @@ public class ClientEventHandler {
         renderer.renderTimer(matrixStack, width, time, timerDuration);
 
         // Render Event Queue...
+        matrixStack.push();
         for (int i = 0; i < currentEvents.size(); i++) {
             currentEvents.get(i).renderQueueItem(matrixStack, tickdelta, width - 200, 20 + (i * 13));
         }
+        matrixStack.pop();
 
         // Render Poll...
         if (Entropy.getInstance().settings.integrations && serverIntegrations && votingClient != null && votingClient.enabled) {

--- a/src/main/java/me/juancarloscp52/entropy/events/AbstractMultiEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/AbstractMultiEvent.java
@@ -6,6 +6,8 @@ import java.util.List;
 import me.juancarloscp52.entropy.Entropy;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.network.PacketByteBuf;
 
@@ -59,12 +61,19 @@ public abstract class AbstractMultiEvent implements Event {
 
     @Override
     public void renderQueueItem(MatrixStack matrixStack, float tickdelta, int x, int y) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        int barLeft = client.getWindow().getScaledWidth() - 39;
+
+        DrawableHelper.fill(matrixStack, barLeft, y, barLeft + 2, y + events.size() * 13 - 5, 0xFFFFFFFF);
+
         for(int i = 0; i < events.size(); i++) {
             Event event = events.get(i);
 
-            matrixStack.translate(0, 13, 0);
             event.renderQueueItem(matrixStack, tickdelta, x, y);
+            matrixStack.translate(0, 13, 0);
         }
+
+        matrixStack.translate(0, -13, 0);
     }
 
     @Override

--- a/src/main/java/me/juancarloscp52/entropy/events/AbstractMultiEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/AbstractMultiEvent.java
@@ -1,0 +1,154 @@
+package me.juancarloscp52.entropy.events;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import com.google.common.base.Suppliers;
+
+import me.juancarloscp52.entropy.Entropy;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.network.PacketByteBuf;
+
+public abstract class AbstractMultiEvent implements Event {
+    private List<Event> events = List.of();
+    private short tickCount = 0;
+    private boolean ended = false;
+    private Supplier<Short> duration = () -> Short.MAX_VALUE;
+
+    @Override
+    public void init() {
+        events = selectEvents();
+        events.forEach(Event::init);
+        duration = Suppliers.memoize(() -> {
+            short longestDuration = 0;
+
+            for(Event event : events) {
+                short eventDuration = event.getDuration();
+
+                if(eventDuration > longestDuration)
+                    longestDuration = eventDuration;
+            }
+
+            return longestDuration;
+        });
+    }
+
+    @Override
+    @Environment(EnvType.CLIENT)
+    public void initClient() {
+        events.forEach(event -> {
+            if(!(event.isDisabledByAccessibilityMode() && Entropy.getInstance().settings.accessibilityMode))
+                event.initClient();
+        });
+    }
+
+    @Override
+    public void end() {
+        events.forEach(event -> {
+            if(!event.hasEnded())
+                event.end();
+        });
+    }
+
+    @Override
+    @Environment(EnvType.CLIENT)
+    public void endClient() {
+        events.forEach(event -> {
+            if(!event.hasEnded())
+                event.endClient();
+        });
+    }
+
+    @Override
+    public void render(MatrixStack matrixStack, float tickdelta) {
+        events.forEach(event -> {
+            if(!event.hasEnded())
+                event.render(matrixStack, tickdelta);
+        });
+    }
+
+    @Override
+    public void renderQueueItem(MatrixStack matrixStack, float tickdelta, int x, int y) {
+        for(int i = 0; i < events.size(); i++) {
+            Event event = events.get(i);
+
+            matrixStack.translate(0, i * 13, 0);
+            event.renderQueueItem(matrixStack, tickdelta, x, y);
+        }
+    }
+
+    @Override
+    public void tick() {
+        tickCount++;
+        events.forEach(event -> {
+            if(!event.hasEnded())
+                event.tick();
+        });
+
+        if(tickCount >= getDuration())
+            end();
+    }
+
+    @Override
+    public void tickClient() {
+        tickCount++;
+        events.forEach(event -> {
+            if(!event.hasEnded())
+                event.tickClient();
+        });
+
+        if(tickCount >= getDuration())
+            endClient();
+    }
+
+    @Override
+    public short getTickCount() {
+        return tickCount;
+    }
+
+    @Override
+    public void setTickCount(short tickCount) {
+        this.tickCount = tickCount;
+    }
+
+    @Override
+    public short getDuration() {
+        return duration.get();
+    }
+
+    @Override
+    public boolean hasEnded() {
+        return ended || events.stream().allMatch(Event::hasEnded);
+    }
+
+    @Override
+    public void setEnded(boolean ended) {
+        this.ended = ended;
+    }
+
+    @Override
+    public void writeExtraData(PacketByteBuf buf) {
+        buf.writeInt(events.size());
+        events.forEach(event -> buf.writeString(EventRegistry.getEventId(event)));
+        events.forEach(event -> event.writeExtraData(buf));
+    }
+
+    @Override
+    @Environment(EnvType.CLIENT)
+    public void readExtraData(PacketByteBuf buf) {
+        int eventCount = buf.readInt();
+
+        events = new ArrayList<>();
+
+        for(int i = 0; i < eventCount; i++) {
+            events.add(EventRegistry.get(buf.readString()));
+        }
+
+        events.forEach(event -> event.readExtraData(buf));
+    }
+
+    public abstract List<Event> selectEvents();
+}

--- a/src/main/java/me/juancarloscp52/entropy/events/AbstractMultiEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/AbstractMultiEvent.java
@@ -151,4 +151,8 @@ public abstract class AbstractMultiEvent implements Event {
     }
 
     public abstract List<Event> selectEvents();
+
+    public List<Event> selectedEvents() {
+        return events;
+    }
 }

--- a/src/main/java/me/juancarloscp52/entropy/events/AbstractMultiEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/AbstractMultiEvent.java
@@ -62,7 +62,7 @@ public abstract class AbstractMultiEvent implements Event {
         for(int i = 0; i < events.size(); i++) {
             Event event = events.get(i);
 
-            matrixStack.translate(0, i * 13, 0);
+            matrixStack.translate(0, 13, 0);
             event.renderQueueItem(matrixStack, tickdelta, x, y);
         }
     }

--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -209,12 +209,18 @@ public class EventRegistry {
 
         Set<String> ignoreTypes = new HashSet<>();
         events.forEach(event -> {
-            if(event.getTickCount()>0 && !event.hasEnded()) {
-                if(!event.type().equalsIgnoreCase("none"))
-                    ignoreTypes.add(event.type().toLowerCase());
+            if(!event.hasEnded()) {
+                if(event.getTickCount()>0) {
+                    if(!event.type().equalsIgnoreCase("none"))
+                        ignoreTypes.add(event.type().toLowerCase());
+                }
 
-                if(event instanceof AbstractMultiEvent multiEvent)
+                if(event instanceof AbstractMultiEvent multiEvent) {
+                    if(!event.type().equalsIgnoreCase("none"))
+                        ignoreTypes.add(event.type().toLowerCase());
+
                     ignoreTypes.addAll(multiEvent.selectedEvents().stream().map(ev -> ev.type().toLowerCase()).toList());
+                }
             }
         });
         Set<String> ignoreEventsByType = new HashSet<>();

--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -207,8 +207,13 @@ public class EventRegistry {
 
         Set<String> ignoreTypes = new HashSet<>();
         events.forEach(event -> {
-            if(event.getTickCount()>0 && !event.hasEnded() && !event.type().equalsIgnoreCase("none"))
-                ignoreTypes.add(event.type().toLowerCase());
+            if(event.getTickCount()>0 && !event.hasEnded()) {
+                if(!event.type().equalsIgnoreCase("none"))
+                    ignoreTypes.add(event.type().toLowerCase());
+
+                if(event instanceof AbstractMultiEvent multiEvent)
+                    ignoreTypes.addAll(multiEvent.selectedEvents().stream().map(ev -> ev.type().toLowerCase()).toList());
+            }
         });
         Set<String> ignoreEventsByType = new HashSet<>();
         eventKeys.forEach(eventName -> {

--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -210,16 +210,16 @@ public class EventRegistry {
         Set<String> ignoreTypes = new HashSet<>();
         events.forEach(event -> {
             if(!event.hasEnded()) {
-                if(event.getTickCount()>0) {
-                    if(!event.type().equalsIgnoreCase("none"))
-                        ignoreTypes.add(event.type().toLowerCase());
-                }
-
                 if(event instanceof AbstractMultiEvent multiEvent) {
                     if(!event.type().equalsIgnoreCase("none"))
                         ignoreTypes.add(event.type().toLowerCase());
 
                     ignoreTypes.addAll(multiEvent.selectedEvents().stream().map(ev -> ev.type().toLowerCase()).toList());
+                }
+
+                if(event.getTickCount()>0) {
+                    if(!event.type().equalsIgnoreCase("none"))
+                        ignoreTypes.add(event.type().toLowerCase());
                 }
             }
         });

--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -192,6 +192,8 @@ public class EventRegistry {
         entropyEvents.put("OnePunchEvent", OnePunchEvent::new);
         entropyEvents.put("InfestationEvent", InfestationEvent::new);
         entropyEvents.put("RainbowPathEvent", RainbowPathEvent::new);
+        entropyEvents.put("TwoAtOnceEvent", TwoAtOnceEvent::new);
+        entropyEvents.put("FiveAtOnceEvent", FiveAtOnceEvent::new);
 
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/events/db/FiveAtOnceEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/FiveAtOnceEvent.java
@@ -7,16 +7,8 @@ import me.juancarloscp52.entropy.Entropy;
 import me.juancarloscp52.entropy.events.AbstractMultiEvent;
 import me.juancarloscp52.entropy.events.Event;
 import me.juancarloscp52.entropy.events.EventRegistry;
-import net.minecraft.client.gui.DrawableHelper;
-import net.minecraft.client.util.math.MatrixStack;
 
 public class FiveAtOnceEvent extends AbstractMultiEvent {
-    @Override
-    public void renderQueueItem(MatrixStack matrixStack, float tickdelta, int x, int y) {
-        DrawableHelper.fill(matrixStack, x - 5, y, x - 3, y + 5 * 13, 0xFFFFFF);
-        super.renderQueueItem(matrixStack, tickdelta, x, y);
-    }
-
     @Override
     public List<Event> selectEvents() {
         List<Event> selectedEvents = new ArrayList<>();

--- a/src/main/java/me/juancarloscp52/entropy/events/db/FiveAtOnceEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/FiveAtOnceEvent.java
@@ -1,0 +1,39 @@
+package me.juancarloscp52.entropy.events.db;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.events.AbstractMultiEvent;
+import me.juancarloscp52.entropy.events.Event;
+import me.juancarloscp52.entropy.events.EventRegistry;
+import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.util.math.MatrixStack;
+
+public class FiveAtOnceEvent extends AbstractMultiEvent {
+    @Override
+    public void renderQueueItem(MatrixStack matrixStack, float tickdelta, int x, int y) {
+        DrawableHelper.fill(matrixStack, x - 5, y, x - 3, y + 5 * 13, 0xFFFFFF);
+        super.renderQueueItem(matrixStack, tickdelta, x, y);
+    }
+
+    @Override
+    public List<Event> selectEvents() {
+        List<Event> selectedEvents = new ArrayList<>();
+        List<Event> currentEvents = new ArrayList<>(Entropy.getInstance().eventHandler.currentEvents);
+
+        for(int i = 0; i < 5; i++) {
+            Event event = EventRegistry.getRandomDifferentEvent(currentEvents);
+
+            selectedEvents.add(event);
+            currentEvents.add(event);
+        }
+
+        return selectedEvents;
+    }
+
+    @Override
+    public String type() {
+        return "multi";
+    }
+}

--- a/src/main/java/me/juancarloscp52/entropy/events/db/TwoAtOnceEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/TwoAtOnceEvent.java
@@ -1,0 +1,38 @@
+package me.juancarloscp52.entropy.events.db;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.events.AbstractMultiEvent;
+import me.juancarloscp52.entropy.events.Event;
+import me.juancarloscp52.entropy.events.EventRegistry;
+import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.util.math.MatrixStack;
+
+public class TwoAtOnceEvent extends AbstractMultiEvent {
+    @Override
+    public void renderQueueItem(MatrixStack matrixStack, float tickdelta, int x, int y) {
+        DrawableHelper.fill(matrixStack, x - 5, y, x - 3, y + 2 * 13, 0xFFFFFF);
+        super.renderQueueItem(matrixStack, tickdelta, x, y);
+    }
+
+    @Override
+    public List<Event> selectEvents() {
+        List<Event> selectedEvents = new ArrayList<>();
+        List<Event> currentEvents = new ArrayList<>(Entropy.getInstance().eventHandler.currentEvents);
+        Event firstEvent = EventRegistry.getRandomDifferentEvent(currentEvents);
+
+        selectedEvents.add(firstEvent);
+        currentEvents.add(firstEvent);
+        selectedEvents.add(EventRegistry.getRandomDifferentEvent(currentEvents));
+        System.out.println(selectedEvents);
+        System.out.println(this);
+        return selectedEvents;
+    }
+
+    @Override
+    public String type() {
+        return "multi";
+    }
+}

--- a/src/main/java/me/juancarloscp52/entropy/events/db/TwoAtOnceEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/TwoAtOnceEvent.java
@@ -7,16 +7,8 @@ import me.juancarloscp52.entropy.Entropy;
 import me.juancarloscp52.entropy.events.AbstractMultiEvent;
 import me.juancarloscp52.entropy.events.Event;
 import me.juancarloscp52.entropy.events.EventRegistry;
-import net.minecraft.client.gui.DrawableHelper;
-import net.minecraft.client.util.math.MatrixStack;
 
 public class TwoAtOnceEvent extends AbstractMultiEvent {
-    @Override
-    public void renderQueueItem(MatrixStack matrixStack, float tickdelta, int x, int y) {
-        DrawableHelper.fill(matrixStack, x - 5, y, x - 3, y + 2 * 13, 0xFFFFFF);
-        super.renderQueueItem(matrixStack, tickdelta, x, y);
-    }
-
     @Override
     public List<Event> selectEvents() {
         List<Event> selectedEvents = new ArrayList<>();

--- a/src/main/java/me/juancarloscp52/entropy/events/db/TwoAtOnceEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/TwoAtOnceEvent.java
@@ -18,8 +18,6 @@ public class TwoAtOnceEvent extends AbstractMultiEvent {
         selectedEvents.add(firstEvent);
         currentEvents.add(firstEvent);
         selectedEvents.add(EventRegistry.getRandomDifferentEvent(currentEvents));
-        System.out.println(selectedEvents);
-        System.out.println(this);
         return selectedEvents;
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/server/ServerEventHandler.java
+++ b/src/main/java/me/juancarloscp52/entropy/server/ServerEventHandler.java
@@ -72,9 +72,9 @@ public class ServerEventHandler {
 
                 if (currentEvents.get(0).hasEnded()) {
                     PlayerLookup.all(server).forEach(serverPlayerEntity ->
-                            ServerPlayNetworking.send(serverPlayerEntity,
-                                    NetworkingConstants.REMOVE_FIRST,
-                                    PacketByteBufs.empty()));
+                    ServerPlayNetworking.send(serverPlayerEntity,
+                            NetworkingConstants.REMOVE_FIRST,
+                            PacketByteBufs.empty()));
 
                     currentEvents.remove(0);
                 }
@@ -122,22 +122,22 @@ public class ServerEventHandler {
         PacketByteBuf buf = PacketByteBufs.create();
         buf.writeShort(eventCountDown);
         PlayerLookup.all(server).forEach(serverPlayerEntity ->
-                ServerPlayNetworking.send(serverPlayerEntity, NetworkingConstants.TICK, buf));
+        ServerPlayNetworking.send(serverPlayerEntity, NetworkingConstants.TICK, buf));
 
 
         eventCountDown--;
     }
-    
+
     public boolean runEvent(Event event) {
         if(event != null) {
             // Start the event and add it to the list.
-            event.init();
             currentEvents.add(event);
+            event.init();
 
             sendEventToPlayers(event);
             return true;
         }
-        
+
         return false;
     }
 
@@ -148,7 +148,7 @@ public class ServerEventHandler {
         packetByteBuf.writeString(eventName);
         event.writeExtraData(packetByteBuf);
         PlayerLookup.all(server).forEach(serverPlayerEntity ->
-                ServerPlayNetworking.send(serverPlayerEntity, NetworkingConstants.ADD_EVENT, packetByteBuf));
+        ServerPlayNetworking.send(serverPlayerEntity, NetworkingConstants.ADD_EVENT, packetByteBuf));
 
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/server/ServerEventHandler.java
+++ b/src/main/java/me/juancarloscp52/entropy/server/ServerEventHandler.java
@@ -72,9 +72,9 @@ public class ServerEventHandler {
 
                 if (currentEvents.get(0).hasEnded()) {
                     PlayerLookup.all(server).forEach(serverPlayerEntity ->
-                    ServerPlayNetworking.send(serverPlayerEntity,
-                            NetworkingConstants.REMOVE_FIRST,
-                            PacketByteBufs.empty()));
+                        ServerPlayNetworking.send(serverPlayerEntity,
+                                NetworkingConstants.REMOVE_FIRST,
+                                PacketByteBufs.empty()));
 
                     currentEvents.remove(0);
                 }
@@ -122,7 +122,7 @@ public class ServerEventHandler {
         PacketByteBuf buf = PacketByteBufs.create();
         buf.writeShort(eventCountDown);
         PlayerLookup.all(server).forEach(serverPlayerEntity ->
-        ServerPlayNetworking.send(serverPlayerEntity, NetworkingConstants.TICK, buf));
+            ServerPlayNetworking.send(serverPlayerEntity, NetworkingConstants.TICK, buf));
 
 
         eventCountDown--;
@@ -148,7 +148,7 @@ public class ServerEventHandler {
         packetByteBuf.writeString(eventName);
         event.writeExtraData(packetByteBuf);
         PlayerLookup.all(server).forEach(serverPlayerEntity ->
-        ServerPlayNetworking.send(serverPlayerEntity, NetworkingConstants.ADD_EVENT, packetByteBuf));
+            ServerPlayNetworking.send(serverPlayerEntity, NetworkingConstants.ADD_EVENT, packetByteBuf));
 
     }
 

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -156,6 +156,8 @@
   "entropy.events.OnePunchEvent": "Ein Schlag",
   "entropy.events.InfestationEvent": "Verseuchung",
   "entropy.events.RainbowPathEvent": "Regenbogenpfad",
+  "entropy.events.TwoAtOnceEvent": "Zwei Ereignisse gleichzeitig",
+  "entropy.events.FiveAtOnceEvent": "Fünf Ereignisse gleichzeitig",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -156,6 +156,8 @@
   "entropy.events.OnePunchEvent": "Ein Schlag",
   "entropy.events.InfestationEvent": "Verseuchung",
   "entropy.events.RainbowPathEvent": "Regenbogenpfad",
+  "entropy.events.TwoAtOnceEvent": "Zwei Ereignisse gleichzeitig",
+  "entropy.events.FiveAtOnceEvent": "Fünf Ereignisse gleichzeitig",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -156,6 +156,8 @@
   "entropy.events.OnePunchEvent": "Ein Schlag",
   "entropy.events.InfestationEvent": "Verseuchung",
   "entropy.events.RainbowPathEvent": "Regenbogenpfad",
+  "entropy.events.TwoAtOnceEvent": "Zwei Ereignisse gleichzeitig",
+  "entropy.events.FiveAtOnceEvent": "Fünf Ereignisse gleichzeitig",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",

--- a/src/main/resources/assets/entropy/lang/en_gb.json
+++ b/src/main/resources/assets/entropy/lang/en_gb.json
@@ -129,7 +129,9 @@
   "entropy.events.EntityMagnetEvent": "Entity magnet",
   "entropy.events.OnePunchEvent": "One Punch",
   "entropy.events.InfestationEvent": "Infestation",
-  "entropy.events.RainbowPathEvent": "Rainbow Path",
+  "entropy.events.RainbowPathEvent": "Rainbow path",
+  "entropy.events.TwoAtOnceEvent": "Two events at once",
+  "entropy.events.FiveAtOnceEvent": "Five events at once",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.errorScreen.title": "Entropy Error",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -156,6 +156,8 @@
   "entropy.events.OnePunchEvent": "One Punch",
   "entropy.events.InfestationEvent": "Infestation",
   "entropy.events.RainbowPathEvent": "Rainbow Path",
+  "entropy.events.TwoAtOnceEvent": "Two Events At Once",
+  "entropy.events.FiveAtOnceEvent": "Five Events At Once",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unknown event: %s",


### PR DESCRIPTION
This pull request adds a new abstract event `AbstractMultiEvent` as well as two new events `TwoAtOnceEvent` and `FiveAtOnceEvent` that make use of it - they run two/five events at the same time respectively. `AbstractMultiEvent` is useful for handling multiple events at once. Subclasses can select events they want to run, and `AbstractMultiEvent` handles the rest. The events get rendered as a group in the queue as well. I have at least one more event planned that can make use of this. Here's a showcase of how it looks:
![](https://i.imgur.com/Ce3torz.png)

This PR is a draft because there are still some issues with this, but I still wanted to gather some feedback on this idea as well as perhaps get help with fixing these issues. I currently know of:
- Having very few events active including both of the new onces leads to a StackOverflowException when activating one of the new events (tested with only the two new events, as well as the new ones + another one for a total of 3)
- Sometimes with just a few events enabled that include the new events, the queue will be incorrect. ![](https://i.imgur.com/piv6zee.png) (tested with the two new events + 3 others for a total of 5)