### PR TITLE
Revamp One Heart event to Half-Hearted

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -74,7 +74,7 @@ public class EventRegistry {
         entropyEvents.put("MouseDriftingEvent", MouseDriftingEvent::new);
         entropyEvents.put("NoDropsEvent", NoDropsEvent::new);
         entropyEvents.put("NoJumpEvent", NoJumpEvent::new);
-        entropyEvents.put("OneHeartEvent", OneHeartEvent::new);
+        entropyEvents.put("HalfHeartedEvent", HalfHeartedEvent::new);
         entropyEvents.put("OnlyBackwardsEvent", OnlyBackwardsEvent::new);
         entropyEvents.put("OnlySidewaysEvent", OnlySidewaysEvent::new);
         entropyEvents.put("PlaceLavaBlockEvent", PlaceLavaBlockEvent::new);

--- a/src/main/java/me/juancarloscp52/entropy/events/db/HalfHeartedEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/HalfHeartedEvent.java
@@ -17,32 +17,42 @@
 
 package me.juancarloscp52.entropy.events.db;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import me.juancarloscp52.entropy.Entropy;
 import me.juancarloscp52.entropy.events.AbstractTimedEvent;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.server.network.ServerPlayerEntity;
 
-public class OneHeartEvent extends AbstractTimedEvent {
+public class HalfHeartedEvent extends AbstractTimedEvent {
+    private Map<ServerPlayerEntity,Float> previousHealth = new HashMap<>();
 
     @Override
     public void init() {
         Entropy.getInstance().eventHandler.getActivePlayers().forEach(serverPlayerEntity -> {
-            serverPlayerEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(2);
-            if (serverPlayerEntity.getHealth() > 2)
-                serverPlayerEntity.setHealth(2);
+            serverPlayerEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(1);
+            previousHealth.put(serverPlayerEntity, serverPlayerEntity.getHealth());
+
+            if (serverPlayerEntity.getHealth() > 1)
+                serverPlayerEntity.setHealth(1);
         });
     }
 
     @Override
     public void end() {
-        Entropy.getInstance().eventHandler.getActivePlayers().forEach(serverPlayerEntity -> serverPlayerEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(20));
+        Entropy.getInstance().eventHandler.getActivePlayers().forEach(serverPlayerEntity -> {
+            serverPlayerEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(20);
+            serverPlayerEntity.setHealth(previousHealth.get(serverPlayerEntity));
+        });
         this.hasEnded = true;
     }
 
     @Override
     public void endPlayer(ServerPlayerEntity player) {
         player.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(20);
+        player.setHealth(previousHealth.get(player));
     }
 
     @Override
@@ -53,9 +63,13 @@ public class OneHeartEvent extends AbstractTimedEvent {
     public void tick() {
         if (this.getTickCount() % 20 == 0) {
             Entropy.getInstance().eventHandler.getActivePlayers().forEach(serverPlayerEntity -> {
-                serverPlayerEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(2);
-                if (serverPlayerEntity.getHealth() > 2)
-                    serverPlayerEntity.setHealth(2);
+                serverPlayerEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(1);
+
+                if(!previousHealth.containsKey(serverPlayerEntity))
+                    previousHealth.put(serverPlayerEntity, serverPlayerEntity.getHealth());
+
+                if (serverPlayerEntity.getHealth() > 1)
+                    serverPlayerEntity.setHealth(1);
             });
         }
         super.tick();

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -35,7 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "Gewitter!",
   "entropy.events.HighPitchEvent": "Hohe Tonhöhe",
   "entropy.events.LowPitchEvent": "Tiefe Tonhöhe",
-  "entropy.events.OneHeartEvent": "Ein Herz",
+  "entropy.events.HalfHeartedEvent": "Halb-Herzig",
   "entropy.events.HyperSpeedEvent": "Hypergeschwindigkeit",
   "entropy.events.HyperSlowEvent": "Hyperlangsam",
   "entropy.events.UltraFovEvent": "Quake Fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -35,7 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "Gewitter!",
   "entropy.events.HighPitchEvent": "Hohe Tonhöhe",
   "entropy.events.LowPitchEvent": "Tiefe Tonhöhe",
-  "entropy.events.OneHeartEvent": "Ein Herz",
+  "entropy.events.HalfHeartedEvent": "Halb-Herzig",
   "entropy.events.HyperSpeedEvent": "Hypergeschwindigkeit",
   "entropy.events.HyperSlowEvent": "Hyperlangsam",
   "entropy.events.UltraFovEvent": "Quake Fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -35,7 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "Gewitter!",
   "entropy.events.HighPitchEvent": "Hohe Tonhöhe",
   "entropy.events.LowPitchEvent": "Tiefe Tonhöhe",
-  "entropy.events.OneHeartEvent": "Ein Herz",
+  "entropy.events.HalfHeartedEvent": "Halb-Herzig",
   "entropy.events.HyperSpeedEvent": "Hypergeschwindigkeit",
   "entropy.events.HyperSlowEvent": "Hyperlangsam",
   "entropy.events.UltraFovEvent": "Quake Fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -35,7 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "Thunderstorm!",
   "entropy.events.HighPitchEvent": "High Pitch",
   "entropy.events.LowPitchEvent": "Low Pitch",
-  "entropy.events.OneHeartEvent": "One Heart",
+  "entropy.events.HalfHeartedEvent": "Half-Hearted",
   "entropy.events.HyperSpeedEvent": "Hyper Speed",
   "entropy.events.HyperSlowEvent": "Hyper Slow",
   "entropy.events.UltraFovEvent": "Quake Fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_ar.json
+++ b/src/main/resources/assets/entropy/lang/es_ar.json
@@ -35,6 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
+  "entropy.events.HalfHeartedEvent": "Medio corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_ar.json
+++ b/src/main/resources/assets/entropy/lang/es_ar.json
@@ -35,7 +35,6 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
-  "entropy.events.OneHeartEvent": "Un corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_cl.json
+++ b/src/main/resources/assets/entropy/lang/es_cl.json
@@ -35,6 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
+  "entropy.events.HalfHeartedEvent": "Medio corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_cl.json
+++ b/src/main/resources/assets/entropy/lang/es_cl.json
@@ -35,7 +35,6 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
-  "entropy.events.OneHeartEvent": "Un corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_ec.json
+++ b/src/main/resources/assets/entropy/lang/es_ec.json
@@ -35,6 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
+  "entropy.events.HalfHeartedEvent": "Medio corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_ec.json
+++ b/src/main/resources/assets/entropy/lang/es_ec.json
@@ -35,7 +35,6 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
-  "entropy.events.OneHeartEvent": "Un corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -35,6 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
+  "entropy.events.HalfHeartedEvent": "Medio corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -35,7 +35,6 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
-  "entropy.events.OneHeartEvent": "Un corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_mx.json
+++ b/src/main/resources/assets/entropy/lang/es_mx.json
@@ -35,6 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
+  "entropy.events.HalfHeartedEvent": "Medio corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_mx.json
+++ b/src/main/resources/assets/entropy/lang/es_mx.json
@@ -35,7 +35,6 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
-  "entropy.events.OneHeartEvent": "Un corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_uy.json
+++ b/src/main/resources/assets/entropy/lang/es_uy.json
@@ -35,6 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
+  "entropy.events.HalfHeartedEvent": "Medio corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_uy.json
+++ b/src/main/resources/assets/entropy/lang/es_uy.json
@@ -35,7 +35,6 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
-  "entropy.events.OneHeartEvent": "Un corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_ve.json
+++ b/src/main/resources/assets/entropy/lang/es_ve.json
@@ -35,6 +35,7 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
+  "entropy.events.HalfHeartedEvent": "Medio corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/es_ve.json
+++ b/src/main/resources/assets/entropy/lang/es_ve.json
@@ -35,7 +35,6 @@
   "entropy.events.IntenseThunderStormEvent": "¡Tormenta!",
   "entropy.events.HighPitchEvent": "Sonidos agudos",
   "entropy.events.LowPitchEvent": "Sonidos graves",
-  "entropy.events.OneHeartEvent": "Un corazón",
   "entropy.events.HyperSpeedEvent": "Hyper velocidad",
   "entropy.events.HyperSlowEvent": "Hyper lento",
   "entropy.events.UltraFovEvent": "Quake fov? QUAKE FOOOOV!",

--- a/src/main/resources/assets/entropy/lang/zh_cn.json
+++ b/src/main/resources/assets/entropy/lang/zh_cn.json
@@ -35,7 +35,6 @@
   "entropy.events.IntenseThunderStormEvent": "雷暴",
   "entropy.events.HighPitchEvent": "高音",
   "entropy.events.LowPitchEvent": "低音",
-  "entropy.events.OneHeartEvent": "一颗心",
   "entropy.events.HyperSpeedEvent": "超高速",
   "entropy.events.HyperSlowEvent": "超低速",
   "entropy.events.UltraFovEvent": "超大大大大大视野!",


### PR DESCRIPTION
Changes made to the one heart event:
- Now called "Half-Hearted". This change was made because it is a popular datapack in the Minecraft community[^1][^2], and also stays more true to the GTAV chaos mod's "One Hit K.O.".
- Health is reduced to half a heart instead of one heart, meaning any damage will kill the player
- When the event ends, each player's health is now restored to the amount it was before the event started. This benefits players as they no longer need to deal with the effects of the event after it has ended.

[^1]: https://www.youtube.com/watch?v=wHaqPL317ZM
[^2]: https://www.speedrun.com/mc_dmce?h=HHH_Any_Glitchless-Random_Seed-1.16&x=7dgxmmpk-jlzr1xy8.rqv77ywq-9l7xq54n.0q5663n1