### PR TITLE
Add rainbow trails event

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/Entropy.java
+++ b/src/main/java/me/juancarloscp52/entropy/Entropy.java
@@ -22,6 +22,7 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import me.juancarloscp52.entropy.events.Event;
 import me.juancarloscp52.entropy.events.EventRegistry;
+import me.juancarloscp52.entropy.server.ConstantColorDustParticleEffect;
 import me.juancarloscp52.entropy.server.ServerEventHandler;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
@@ -32,13 +33,19 @@ import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.api.particle.v1.FabricParticleTypes;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.CommandSource;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.particle.ParticleType;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -53,6 +60,7 @@ public class Entropy implements ModInitializer {
     public static Entropy instance;
     public ServerEventHandler eventHandler;
     public EntropySettings settings;
+    public static final ParticleType<ConstantColorDustParticleEffect> CONSTANT_COLOR_DUST = FabricParticleTypes.complex(false, ConstantColorDustParticleEffect.PARAMETERS_FACTORY);
 
 
     public static Entropy getInstance() {
@@ -65,6 +73,7 @@ public class Entropy implements ModInitializer {
         loadSettings();
         LOGGER.info("Entropy Started");
         EventRegistry.register();
+        Registry.register(Registries.PARTICLE_TYPE, new Identifier("entropy", "constant_color_dust"), CONSTANT_COLOR_DUST);
 
         ServerPlayNetworking.registerGlobalReceiver(NetworkingConstants.JOIN_HANDSHAKE, (server, player, handler, buf, responseSender) -> {
             String clientVersion = buf.readString(32767);

--- a/src/main/java/me/juancarloscp52/entropy/EntropyTags.java
+++ b/src/main/java/me/juancarloscp52/entropy/EntropyTags.java
@@ -31,6 +31,7 @@ public class EntropyTags {
         public static final TagKey<EntityType<?>> DO_NOT_LEVITATE = TagKey.of(Registries.ENTITY_TYPE.getKey(), new Identifier("entropy", "do_not_levitate"));
         public static final TagKey<EntityType<?>> IGNORED_BY_FORCEFIELD_AND_ENTITY_MAGNET = TagKey.of(Registries.ENTITY_TYPE.getKey(), new Identifier("entropy", "ignored_by_forcefield_and_entity_magnet"));
         public static final TagKey<EntityType<?>> IGNORED_BY_MIDAS_TOUCH = TagKey.of(Registries.ENTITY_TYPE.getKey(), new Identifier("entropy", "ignored_by_midas_touch"));
+        public static final TagKey<EntityType<?>> NO_RAINBOW_TRAIL = TagKey.of(Registries.ENTITY_TYPE.getKey(), new Identifier("entropy", "no_rainbow_trail"));
         public static final TagKey<EntityType<?>> NOT_INVISIBLE = TagKey.of(Registries.ENTITY_TYPE.getKey(), new Identifier("entropy", "not_invisible"));
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/client/ConstantColorDustParticle.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/ConstantColorDustParticle.java
@@ -1,0 +1,32 @@
+package me.juancarloscp52.entropy.client;
+
+import me.juancarloscp52.entropy.server.ConstantColorDustParticleEffect;
+import net.fabricmc.fabric.api.client.particle.v1.FabricSpriteProvider;
+import net.minecraft.client.particle.AbstractDustParticle;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.particle.ParticleFactory;
+import net.minecraft.client.particle.SpriteProvider;
+import net.minecraft.client.world.ClientWorld;
+
+public class ConstantColorDustParticle extends AbstractDustParticle<ConstantColorDustParticleEffect>{
+    protected ConstantColorDustParticle(ClientWorld world, double x, double y, double z, double velocityX, double velocityY, double velocityZ, ConstantColorDustParticleEffect parameters, SpriteProvider spriteProvider) {
+        super(world, x, y, z, velocityX, velocityY, velocityZ, parameters, spriteProvider);
+    }
+
+    @Override
+    protected float darken(float colorComponent, float multiplier) {
+        return colorComponent;
+    }
+
+    public static class Factory implements ParticleFactory<ConstantColorDustParticleEffect> {
+        private final SpriteProvider spriteProvider;
+
+        public Factory(FabricSpriteProvider spriteProvider) {
+            this.spriteProvider = spriteProvider;
+        }
+
+        public Particle createParticle(ConstantColorDustParticleEffect dustParticleEffect, ClientWorld clientWorld, double x, double y, double z, double velocityX, double velocityY, double velocityZ) {
+            return new ConstantColorDustParticle(clientWorld, x, y, z, velocityX, velocityY, velocityZ, dustParticleEffect, spriteProvider);
+        }
+    }
+}

--- a/src/main/java/me/juancarloscp52/entropy/client/EntropyClient.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/EntropyClient.java
@@ -18,7 +18,6 @@
 package me.juancarloscp52.entropy.client;
 
 import com.google.gson.Gson;
-import com.mojang.blaze3d.systems.RenderSystem;
 import me.juancarloscp52.entropy.Entropy;
 import me.juancarloscp52.entropy.NetworkingConstants;
 import me.juancarloscp52.entropy.Variables;
@@ -29,11 +28,11 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.gl.PostEffectProcessor;
-import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
@@ -191,6 +190,7 @@ public class EntropyClient implements ClientModInitializer {
 
         //Registry.registerReference()
         Registry.register(Registries.SOUND_EVENT, herobrineAmbienceID, herobrineAmbience);
+        ParticleFactoryRegistry.getInstance().register(Entropy.CONSTANT_COLOR_DUST, ConstantColorDustParticle.Factory::new);
     }
 
 

--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -192,6 +192,7 @@ public class EventRegistry {
         entropyEvents.put("OnePunchEvent", OnePunchEvent::new);
         entropyEvents.put("InfestationEvent", InfestationEvent::new);
         entropyEvents.put("RainbowPathEvent", RainbowPathEvent::new);
+        entropyEvents.put("RainbowTrailsEvent", RainbowTrailsEvent::new);
 
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/events/db/RainbowTrailsEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/RainbowTrailsEvent.java
@@ -1,0 +1,100 @@
+package me.juancarloscp52.entropy.events.db;
+
+import org.joml.Quaterniond;
+import org.joml.Vector3f;
+
+import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.EntropyTags.EntityTypeTags;
+import me.juancarloscp52.entropy.events.AbstractTimedEvent;
+import me.juancarloscp52.entropy.server.ConstantColorDustParticleEffect;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.MathHelper;
+
+public class RainbowTrailsEvent extends AbstractTimedEvent {
+    @Override
+    public void tickClient() {
+        super.tickClient();
+        float xOffset = (MathHelper.sin(tickCount) + 1.0F) / 2.0F;
+        float yOffset = (MathHelper.cos(tickCount) + 1.0F) / 2.0F;
+        Vector3f color = HSBtoRGB(((tickCount * 5) % 360) / 360.0F, 1.0F, 1.0F);
+
+        MinecraftClient.getInstance().player.clientWorld.getEntities().forEach(entity -> {
+            if(entity.getType().isIn(EntityTypeTags.NO_RAINBOW_TRAIL))
+                return;
+
+            Quaterniond relativePosition = new Quaterniond(-0.5D + xOffset, 0.0D, -0.5D, 0.0D);
+            float bodyYaw = entity.getBodyYaw();
+            float rotation = (Math.abs(bodyYaw) % 360) * MathHelper.RADIANS_PER_DEGREE * 2.0F;
+
+            if(bodyYaw > 0)
+                rotation *= -1;
+
+            relativePosition.rotateLocalY(rotation);
+            entity.world.addParticle(new ConstantColorDustParticleEffect(color, 1.0F),
+                    entity.getX() + relativePosition.x,
+                    entity.getY() + 0.5D + relativePosition.y + yOffset,
+                    entity.getZ() + relativePosition.z,
+                    0.0D, 0.0D, 0.0D);
+        });
+    }
+
+    @Override
+    public void render(MatrixStack matrixStack, float tickdelta) {}
+
+    @Override
+    public short getDuration() {
+        return Entropy.getInstance().settings.baseEventDuration;
+    }
+
+    private Vector3f HSBtoRGB(float hue, float saturation, float brightness) {
+        int r = 0;
+        int g = 0;
+        int b = 0;
+
+        if (saturation == 0)
+            r = g = b = (int) (brightness * 255.0F + 0.5F);
+        else {
+            float h = (hue - (float) Math.floor(hue)) * 6.0F;
+            float f = h - (float) Math.floor(h);
+            float p = brightness * (1.0F - saturation);
+            float q = brightness * (1.0F - saturation * f);
+            float t = brightness * (1.0F - (saturation * (1.0F - f)));
+
+            switch ((int) h) {
+                case 0:
+                    r = (int) (brightness * 255.0F + 0.5F);
+                    g = (int) (t * 255.0F + 0.5F);
+                    b = (int) (p * 255.0F + 0.5F);
+                    break;
+                case 1:
+                    r = (int) (q * 255.0F + 0.5F);
+                    g = (int) (brightness * 255.0F + 0.5F);
+                    b = (int) (p * 255.0F + 0.5F);
+                    break;
+                case 2:
+                    r = (int) (p * 255.0F + 0.5F);
+                    g = (int) (brightness * 255.0F + 0.5F);
+                    b = (int) (t * 255.0F + 0.5F);
+                    break;
+                case 3:
+                    r = (int) (p * 255.0F + 0.5F);
+                    g = (int) (q * 255.0F + 0.5F);
+                    b = (int) (brightness * 255.0F + 0.5F);
+                    break;
+                case 4:
+                    r = (int) (t * 255.0F + 0.5F);
+                    g = (int) (p * 255.0F + 0.5F);
+                    b = (int) (brightness * 255.0F + 0.5F);
+                    break;
+                case 5:
+                    r = (int) (brightness * 255.0F + 0.5F);
+                    g = (int) (p * 255.0F + 0.5F);
+                    b = (int) (q * 255.0F + 0.5F);
+                    break;
+            }
+        }
+
+        return new Vector3f(r / 255.0F, g / 255.0F, b / 255.0F);
+    }
+}

--- a/src/main/java/me/juancarloscp52/entropy/server/ConstantColorDustParticleEffect.java
+++ b/src/main/java/me/juancarloscp52/entropy/server/ConstantColorDustParticleEffect.java
@@ -1,0 +1,39 @@
+package me.juancarloscp52.entropy.server;
+
+import org.joml.Vector3f;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import me.juancarloscp52.entropy.Entropy;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.particle.AbstractDustParticleEffect;
+import net.minecraft.particle.ParticleEffect;
+import net.minecraft.particle.ParticleType;
+import net.minecraft.util.dynamic.Codecs;
+
+public class ConstantColorDustParticleEffect extends AbstractDustParticleEffect {
+    public static final Codec<ConstantColorDustParticleEffect> CODEC = RecordCodecBuilder.create(instance -> instance.group(Codecs.VECTOR_3F.fieldOf("color").forGetter(effect -> effect.color), Codec.FLOAT.fieldOf("scale").forGetter(effect -> effect.scale)).apply(instance, ConstantColorDustParticleEffect::new));
+    public static final ParticleEffect.Factory<ConstantColorDustParticleEffect> PARAMETERS_FACTORY = new ParticleEffect.Factory<ConstantColorDustParticleEffect>() {
+        public ConstantColorDustParticleEffect read(ParticleType<ConstantColorDustParticleEffect> particleType, StringReader stringReader) throws CommandSyntaxException {
+            Vector3f color = AbstractDustParticleEffect.readColor(stringReader);
+            stringReader.expect(' ');
+            return new ConstantColorDustParticleEffect(color, stringReader.readFloat());
+        }
+
+        public ConstantColorDustParticleEffect read(ParticleType<ConstantColorDustParticleEffect> particleType, PacketByteBuf packetByteBuf) {
+            return new ConstantColorDustParticleEffect(AbstractDustParticleEffect.readColor(packetByteBuf), packetByteBuf.readFloat());
+        }
+    };
+
+    public ConstantColorDustParticleEffect(Vector3f color, float scale) {
+        super(color, scale);
+    }
+
+    @Override
+    public ParticleType<ConstantColorDustParticleEffect> getType() {
+        return Entropy.CONSTANT_COLOR_DUST;
+    }
+}

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -156,6 +156,7 @@
   "entropy.events.OnePunchEvent": "Ein Schlag",
   "entropy.events.InfestationEvent": "Verseuchung",
   "entropy.events.RainbowPathEvent": "Regenbogenpfad",
+  "entropy.events.RainbowTrailsEvent": "Regenbogenspuren",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -156,6 +156,7 @@
   "entropy.events.OnePunchEvent": "Ein Schlag",
   "entropy.events.InfestationEvent": "Verseuchung",
   "entropy.events.RainbowPathEvent": "Regenbogenpfad",
+  "entropy.events.RainbowTrailsEvent": "Regenbogenspuren",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -156,6 +156,7 @@
   "entropy.events.OnePunchEvent": "Ein Schlag",
   "entropy.events.InfestationEvent": "Verseuchung",
   "entropy.events.RainbowPathEvent": "Regenbogenpfad",
+  "entropy.events.RainbowTrailsEvent": "Regenbogenspuren",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -156,6 +156,7 @@
   "entropy.events.OnePunchEvent": "One Punch",
   "entropy.events.InfestationEvent": "Infestation",
   "entropy.events.RainbowPathEvent": "Rainbow Path",
+  "entropy.events.RainbowTrailsEvent": "Rainbow Trails",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unknown event: %s",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -154,9 +154,9 @@
   "entropy.events.ForcefieldEvent": "Campo de fuerza",
   "entropy.events.EntityMagnetEvent": "Imán de entidates",
   "entropy.events.OnePunchEvent": "De un puñetazo",
-
   "entropy.events.InfestationEvent": "Infectar bloques",
   "entropy.events.RainbowPathEvent": "Camino arcoiris",
+  "entropy.events.RainbowTrailsEvent": "Cola arcoiris",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Evento desconocido: %s",

--- a/src/main/resources/assets/entropy/particles/constant_color_dust.json
+++ b/src/main/resources/assets/entropy/particles/constant_color_dust.json
@@ -1,0 +1,12 @@
+{
+  "textures": [
+    "minecraft:generic_7",
+    "minecraft:generic_6",
+    "minecraft:generic_5",
+    "minecraft:generic_4",
+    "minecraft:generic_3",
+    "minecraft:generic_2",
+    "minecraft:generic_1",
+    "minecraft:generic_0"
+  ]
+}


### PR DESCRIPTION
This event adds a rainbow particle trail to the back of every entity. This intentionally includes armor stands, arrows, fireballs, and more. A new tag NO_RAINBOW_TRAIL is added to be able to turn the event off for specific entity types.


https://user-images.githubusercontent.com/5149876/227370020-dbccd65b-f0d6-4874-b89d-4b2cfab3e4a6.mp4

