### PR TITLE
Hide Entropy's overlay when the F3 debug screen is rendered

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/client/ClientEventHandler.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/ClientEventHandler.java
@@ -90,16 +90,16 @@ public class ClientEventHandler {
     }
 
     public void render(MatrixStack matrixStack, float tickdelta) {
-        MinecraftClient client = MinecraftClient.getInstance();
-
-        if (client.options.debugEnabled)
-            return;
-
         // Render active event effects
         currentEvents.forEach(event -> {
             if (!event.hasEnded() && !client.player.isSpectator())
                 event.render(matrixStack, tickdelta);
         });
+
+        MinecraftClient client = MinecraftClient.getInstance();
+
+        if (client.options.debugEnabled)
+            return;
 
         double time = timerDuration - eventCountDown;
         int width = client.getWindow().getScaledWidth();

--- a/src/main/java/me/juancarloscp52/entropy/client/ClientEventHandler.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/ClientEventHandler.java
@@ -90,6 +90,10 @@ public class ClientEventHandler {
     }
 
     public void render(MatrixStack matrixStack, float tickdelta) {
+        MinecraftClient client = MinecraftClient.getInstance();
+
+        if (client.options.debugEnabled)
+            return;
 
         // Render active event effects
         currentEvents.forEach(event -> {
@@ -98,7 +102,7 @@ public class ClientEventHandler {
         });
 
         double time = timerDuration - eventCountDown;
-        int width = MinecraftClient.getInstance().getWindow().getScaledWidth();
+        int width = client.getWindow().getScaledWidth();
 
         // Render timer bar
         /// Only the timer is differentiated in two declination for now but


### PR DESCRIPTION
This is a simple change that hides Entropy's overlay when the player is looking at the debug screen that can be activated with F3. Without this, some parts of the debug screen are obscured by Entropy. This behavior is currently not configurable, but if desired such a setting could easily be added.