### PR TITLE
Make glistering melon available through midas touch and add golden items tag

### DIFF
--- a/src/main/generated/data/entropy/tags/items/midas_touch_golden_items.json
+++ b/src/main/generated/data/entropy/tags/items/midas_touch_golden_items.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "#minecraft:piglin_loved",
+      "required": false
+    },
+    "minecraft:gold_nugget"
+  ]
+}

--- a/src/main/java/me/juancarloscp52/entropy/EntropyTags.java
+++ b/src/main/java/me/juancarloscp52/entropy/EntropyTags.java
@@ -41,6 +41,7 @@ public class EntropyTags {
         public static final TagKey<Item> DO_NOT_CURSE = TagKey.of(Registries.ITEM.getKey(), new Identifier("entropy", "do_not_curse"));
         public static final TagKey<Item> DO_NOT_DAMAGE = TagKey.of(Registries.ITEM.getKey(), new Identifier("entropy", "do_not_damage"));
         public static final TagKey<Item> IGNORED_BY_MIDAS_TOUCH = TagKey.of(Registries.ITEM.getKey(), new Identifier("entropy", "ignored_by_midas_touch"));
+        public static final TagKey<Item> MIDAS_TOUCH_GOLDEN_ITEMS = TagKey.of(Registries.ITEM.getKey(), new Identifier("entropy", "midas_touch_golden_items"));
         public static final TagKey<Item> UNFIXABLE = TagKey.of(Registries.ITEM.getKey(), new Identifier("entropy", "unfixable"));
     }
 }

--- a/src/main/java/me/juancarloscp52/entropy/datagen/EntropyItemTagProvider.java
+++ b/src/main/java/me/juancarloscp52/entropy/datagen/EntropyItemTagProvider.java
@@ -31,6 +31,7 @@ public class EntropyItemTagProvider extends ItemTagProvider{
         getOrCreateTagBuilder(ItemTags.DOES_NOT_DROP_RANDOMLY).addTag(ItemTags.BANNED);
         getOrCreateTagBuilder(ItemTags.DOES_NOT_RAIN).addTag(ItemTags.BANNED);
         getOrCreateTagBuilder(ItemTags.IGNORED_BY_MIDAS_TOUCH).add(Items.AIR);
+        getOrCreateTagBuilder(ItemTags.MIDAS_TOUCH_GOLDEN_ITEMS).addOptionalTag(net.minecraft.registry.tag.ItemTags.PIGLIN_LOVED).add(Items.GOLD_NUGGET);
         getOrCreateTagBuilder(spawnEggsTag).add(Items.ALLAY_SPAWN_EGG,
                 Items.AXOLOTL_SPAWN_EGG,
                 Items.BAT_SPAWN_EGG,

--- a/src/main/java/me/juancarloscp52/entropy/events/db/MidasTouchEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/MidasTouchEvent.java
@@ -117,7 +117,7 @@ public class MidasTouchEvent extends AbstractTimedEvent {
                 if (item.isFood()) {
                     var odds = player.getRandom().nextInt(100);
 
-                    if(item == Items.MELON && odds < 50)
+                    if(item == Items.MELON_SLICE && odds < 50)
                         newItemStack = new ItemStack(Items.GLISTERING_MELON_SLICE, itemStack.getCount());
                     else if (odds < 75)
                         newItemStack = new ItemStack(Items.GOLDEN_CARROT, itemStack.getCount());

--- a/src/main/java/me/juancarloscp52/entropy/events/db/MidasTouchEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/MidasTouchEvent.java
@@ -25,32 +25,6 @@ import java.util.ArrayList;
 
 public class MidasTouchEvent extends AbstractTimedEvent {
 
-    private static ArrayList<Item> _goldenItems = new ArrayList<Item>() {
-        {
-            add(Items.ENCHANTED_GOLDEN_APPLE);
-            add(Items.GOLDEN_APPLE);
-            add(Items.GOLDEN_AXE);
-            add(Items.GOLDEN_BOOTS);
-            add(Items.GOLDEN_CHESTPLATE);
-            add(Items.GOLDEN_HELMET);
-            add(Items.GOLDEN_HOE);
-            add(Items.GOLDEN_HORSE_ARMOR);
-            add(Items.GOLDEN_LEGGINGS);
-            add(Items.GOLDEN_PICKAXE);
-            add(Items.GOLDEN_SHOVEL);
-            add(Items.GOLDEN_SWORD);
-            add(Items.GOLD_BLOCK);
-            add(Items.GOLD_INGOT);
-            add(Items.GOLD_NUGGET);
-            add(Items.GOLD_ORE);
-            add(Items.NETHER_GOLD_ORE);
-            add(Items.RAW_GOLD);
-            add(Items.RAW_GOLD_BLOCK);
-            add(Items.GOLDEN_CARROT);
-            add(Items.GLISTERING_MELON_SLICE);
-        }
-    };
-
     @Override
     public void tick() {
         for (var player : Entropy.getInstance().eventHandler.getActivePlayers()) {
@@ -135,11 +109,9 @@ public class MidasTouchEvent extends AbstractTimedEvent {
             };
             for (var pair : inventoryItems) {
                 var itemStack = pair.getLeft().get(pair.getRight());
-                if (itemStack.isEmpty() || itemStack.isIn(ItemTags.IGNORED_BY_MIDAS_TOUCH))
+                if (itemStack.isEmpty() || itemStack.isIn(ItemTags.IGNORED_BY_MIDAS_TOUCH) || itemStack.isIn(ItemTags.MIDAS_TOUCH_GOLDEN_ITEMS))
                     continue;
                 var item = itemStack.getItem();
-                if (_goldenItems.contains(item))
-                    continue;
 
                 ItemStack newItemStack;
                 if (item.isFood()) {

--- a/src/main/java/me/juancarloscp52/entropy/events/db/MidasTouchEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/MidasTouchEvent.java
@@ -47,6 +47,7 @@ public class MidasTouchEvent extends AbstractTimedEvent {
             add(Items.RAW_GOLD);
             add(Items.RAW_GOLD_BLOCK);
             add(Items.GOLDEN_CARROT);
+            add(Items.GLISTERING_MELON_SLICE);
         }
     };
 
@@ -144,7 +145,9 @@ public class MidasTouchEvent extends AbstractTimedEvent {
                 if (item.isFood()) {
                     var odds = player.getRandom().nextInt(100);
 
-                    if (odds < 75)
+                    if(item == Items.MELON && odds < 50)
+                        newItemStack = new ItemStack(Items.GLISTERING_MELON_SLICE, itemStack.getCount());
+                    else if (odds < 75)
                         newItemStack = new ItemStack(Items.GOLDEN_CARROT, itemStack.getCount());
                     else if (odds < 95)
                         newItemStack = new ItemStack(Items.GOLDEN_APPLE, itemStack.getCount());


### PR DESCRIPTION
1. Melons now have a 50% chance of converting to glistering melons. There is no other way to get glistering melons with midas touch, because they cannot be eaten.
2. Added an item tag `entropy:midas_touch_golden_items` that now includes all of the items that were previously stored in the `_goldenItems` list. This tag contains the item tag `minecraft:piglin_loved` and the golden nugget by default. The addition of the piglin_loved tag means that more items are now considered gold by midas touch than before this change. These are: Gilded Blackstone, Light Weighted Pressure Plate, Bell, Clock, and Glistering Melon Slice.

Sidenote unrelated to this PR: When running the data generators, there were more tag file changes than just adding the new item tag. I did not include these changes as they are not relevant to the PR, but it's worth noting that datagen should be run again. 