### PR TITLE
Improve So Sweet! event

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
@@ -33,7 +33,7 @@ public class SoSweetEvent extends AbstractInstantEvent {
                         if ((blockState.getBlock().equals(Blocks.AIR) || blockState.canBucketPlace(Fluids.WATER))
                                 && world.getBlockState(downBlockPos).isFullCube(world, downBlockPos)) {
                             world.setBlockState(blockPos, sweetBerryBush);
-                            iy++; //no need to check the position above this berry bush, because once won't be placed there anyway
+                            iy++; //no need to check the position above this berry bush, because one won't be placed there anyway
                         }
                     }
                 }

--- a/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
@@ -14,7 +14,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Heightmap.Type;
 
 public class SoSweetEvent extends AbstractInstantEvent {
-    private final BlockState sweetBerryBush = Blocks.SWEET_BERRY_BUSH.getDefaultState().with(Properties.AGE_3, 2);;
+    private final BlockState sweetBerryBush = Blocks.SWEET_BERRY_BUSH.getDefaultState().with(Properties.AGE_3, 2);
 
     @Override
     public void init() {

--- a/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
@@ -6,11 +6,15 @@ package me.juancarloscp52.entropy.events.db;
 
 import me.juancarloscp52.entropy.Entropy;
 import me.juancarloscp52.entropy.events.AbstractInstantEvent;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.state.property.Properties;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.Heightmap.Type;
 
 public class SoSweetEvent extends AbstractInstantEvent {
+    private final BlockState sweetBerryBush = Blocks.SWEET_BERRY_BUSH.getDefaultState().with(Properties.AGE_3, 2);;
 
     @Override
     public void init() {
@@ -20,19 +24,16 @@ public class SoSweetEvent extends AbstractInstantEvent {
             var playerPos = serverPlayerEntity.getBlockPos();
 
             for (int ix = -4; ix < 5; ix++) {
-                for (int iy = -4; iy < 5; iy++) {
-                    for (int iz = -4; iz < 5; iz++) {
-                        if ((ix + iy + iz + 100) % 2 == 1)
-                            continue;
+                for (int iz = -4; iz < 5; iz++) {
+                    if ((ix + iz + 100) % 2 == 1)
+                        continue;
 
-                        var blockPos = playerPos.add(ix, iy, iz);
-                        var blockState = world.getBlockState(blockPos);
-                        var downBlockState = world.getBlockState(blockPos.down());
-                        if ((blockState.getBlock().equals(Blocks.AIR) || blockState.canBucketPlace(Fluids.WATER))
-                                && downBlockState.isFullCube(world, blockPos.down())) {
-                            var state = Blocks.SWEET_BERRY_BUSH.getDefaultState().with(Properties.AGE_3, 2);
-                            world.setBlockState(blockPos, state);
-                        }
+                    var blockPos = world.getTopPosition(Type.MOTION_BLOCKING, new BlockPos(playerPos.getX() + ix, 0, playerPos.getZ() + iz));
+                    var blockState = world.getBlockState(blockPos);
+                    var downBlockState = world.getBlockState(blockPos.down());
+                    if ((blockState.getBlock().equals(Blocks.AIR) || blockState.canBucketPlace(Fluids.WATER))
+                            && downBlockState.isFullCube(world, blockPos.down())) {
+                        world.setBlockState(blockPos, sweetBerryBush);
                     }
                 }
             }

--- a/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
@@ -8,11 +8,12 @@ import me.juancarloscp52.entropy.Entropy;
 import me.juancarloscp52.entropy.events.AbstractInstantEvent;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.SweetBerryBushBlock;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.state.property.Properties;
 
 public class SoSweetEvent extends AbstractInstantEvent {
-    private final BlockState sweetBerryBush = Blocks.SWEET_BERRY_BUSH.getDefaultState().with(Properties.AGE_3, 2);
+    private final BlockState sweetBerryBush = Blocks.SWEET_BERRY_BUSH.getDefaultState().with(SweetBerryBushBlock.AGE, 2);
 
     @Override
     public void init() {

--- a/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
@@ -11,6 +11,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.block.SweetBerryBushBlock;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.state.property.Properties;
+import net.minecraft.util.math.Direction;
 
 public class SoSweetEvent extends AbstractInstantEvent {
     private final BlockState sweetBerryBush = Blocks.SWEET_BERRY_BUSH.getDefaultState().with(SweetBerryBushBlock.AGE, 2);
@@ -32,7 +33,7 @@ public class SoSweetEvent extends AbstractInstantEvent {
                         var downBlockPos = blockPos.down();
                         var blockState = world.getBlockState(blockPos);
                         if ((blockState.getBlock().equals(Blocks.AIR) || blockState.canBucketPlace(Fluids.WATER))
-                                && world.getBlockState(downBlockPos).isFullCube(world, downBlockPos)) {
+                                && world.getBlockState(downBlockPos).isSideSolidFullSquare(world, downBlockPos, Direction.UP)) {
                             world.setBlockState(blockPos, sweetBerryBush);
                             iy++; //no need to check the position above this berry bush, because one won't be placed there anyway
                         }

--- a/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/SoSweetEvent.java
@@ -10,8 +10,6 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.state.property.Properties;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.Heightmap.Type;
 
 public class SoSweetEvent extends AbstractInstantEvent {
     private final BlockState sweetBerryBush = Blocks.SWEET_BERRY_BUSH.getDefaultState().with(Properties.AGE_3, 2);
@@ -28,12 +26,15 @@ public class SoSweetEvent extends AbstractInstantEvent {
                     if ((ix + iz + 100) % 2 == 1)
                         continue;
 
-                    var blockPos = world.getTopPosition(Type.MOTION_BLOCKING, new BlockPos(playerPos.getX() + ix, 0, playerPos.getZ() + iz));
-                    var blockState = world.getBlockState(blockPos);
-                    var downBlockState = world.getBlockState(blockPos.down());
-                    if ((blockState.getBlock().equals(Blocks.AIR) || blockState.canBucketPlace(Fluids.WATER))
-                            && downBlockState.isFullCube(world, blockPos.down())) {
-                        world.setBlockState(blockPos, sweetBerryBush);
+                    for (int iy = -4; iy < 5; iy++) {
+                        var blockPos = playerPos.add(ix, iy, iz);
+                        var downBlockPos = blockPos.down();
+                        var blockState = world.getBlockState(blockPos);
+                        if ((blockState.getBlock().equals(Blocks.AIR) || blockState.canBucketPlace(Fluids.WATER))
+                                && world.getBlockState(downBlockPos).isFullCube(world, downBlockPos)) {
+                            world.setBlockState(blockPos, sweetBerryBush);
+                            iy++; //no need to check the position above this berry bush, because once won't be placed there anyway
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The original implementation had an issue where the checkerboard would be alternating between different y levels, resulting in it not properly continuing when the bushes were placed across varying-height terrain:
![](https://i.imgur.com/FLVw8cw.png)

This PR fixes this by only using x/z to get the checkerboard pattern, and then looping through the the Y column from 4 blocks below to 4 blocks above the player to check for placeable positions.
![](https://i.imgur.com/TTrYH5A.png)

An additional small improvement has been made, moving the creation of the bush block state to a non-static field. This way it is not unnecessarily recreated multiple times (once per iteration) when the event is run.