### PR TITLE
Add armor trim event and a system to disable events based on feature flags

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/Entropy.java
+++ b/src/main/java/me/juancarloscp52/entropy/Entropy.java
@@ -54,6 +54,8 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 public class Entropy implements ModInitializer {
     public static final Logger LOGGER = LogManager.getLogger();
@@ -148,7 +150,12 @@ public class Entropy implements ModInitializer {
                             }))
                     .then(CommandManager.literal("run")
                             .then(CommandManager.argument("event", StringArgumentType.word())
-                                    .suggests((context, builder) -> CommandSource.suggestMatching(EventRegistry.entropyEvents.keySet(), builder))
+                                    .suggests((context, builder) -> {
+                                        Set<String> events = new TreeSet<>(EventRegistry.entropyEvents.keySet());
+
+                                        events.removeIf(event -> !EventRegistry.doesWorldHaveRequiredFeatures(event, context.getSource().getWorld()));
+                                        return CommandSource.suggestMatching(events, builder);
+                                    })
                                     .executes(source -> {
                                         ServerEventHandler eventHandler = Entropy.getInstance().eventHandler;
 

--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -21,6 +21,9 @@ import me.juancarloscp52.entropy.Entropy;
 import me.juancarloscp52.entropy.events.db.*;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.resource.featuretoggle.FeatureFlags;
+import net.minecraft.resource.featuretoggle.FeatureSet;
+import net.minecraft.world.World;
 
 import java.util.*;
 import java.util.function.Supplier;
@@ -31,10 +34,11 @@ public class EventRegistry {
     private static final Random random = new Random();
     //Store constructors for all Entropy Events.
     public static HashMap<String, Supplier<Event>> entropyEvents;
+    public static HashMap<String, FeatureSet> requiredFeatures;
 
     public static void register() {
-
         entropyEvents = new HashMap<>();
+        requiredFeatures = new HashMap<>();
         entropyEvents.put("RemoveEnchantmentsEvent", RemoveEnchantmentsEvent::new);
         entropyEvents.put("ArmorCurseEvent", ArmorCurseEvent::new);
         entropyEvents.put("RaidEvent", RaidEvent::new);
@@ -196,6 +200,9 @@ public class EventRegistry {
         entropyEvents.put("NothingEvent", NothingEvent::new);
         entropyEvents.put("RainbowTrailsEvent", RainbowTrailsEvent::new);
         entropyEvents.put("RainbowSheepEverywhereEvent", RainbowSheepEverywhereEvent::new);
+        String armorTrimEvent = "ArmorTrimEvent";
+        entropyEvents.put(armorTrimEvent, ArmorTrimEvent::new);
+        requiredFeatures.put(armorTrimEvent, FeatureFlags.FEATURE_MANAGER.featureSetOf(FeatureFlags.UPDATE_1_20));
 
     }
 
@@ -229,6 +236,7 @@ public class EventRegistry {
         if(FabricLoader.getInstance().getEnvironmentType() != EnvType.SERVER)
             eventKeys.remove("StutteringEvent");
 
+        eventKeys.removeIf(event -> !EventRegistry.doesWorldHaveRequiredFeatures(event, Entropy.getInstance().eventHandler.server.getOverworld()));
         return getRandomEvent(eventKeys);
     }
 
@@ -276,5 +284,9 @@ public class EventRegistry {
 
     public static String getTranslationKey(String eventID) {
         return "entropy.events." + eventID;
+    }
+
+    public static boolean doesWorldHaveRequiredFeatures(String event, World world) {
+        return requiredFeatures.getOrDefault(event, FeatureFlags.VANILLA_FEATURES).isSubsetOf(world.getEnabledFeatures());
     }
 }

--- a/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/EventRegistry.java
@@ -200,9 +200,7 @@ public class EventRegistry {
         entropyEvents.put("NothingEvent", NothingEvent::new);
         entropyEvents.put("RainbowTrailsEvent", RainbowTrailsEvent::new);
         entropyEvents.put("RainbowSheepEverywhereEvent", RainbowSheepEverywhereEvent::new);
-        String armorTrimEvent = "ArmorTrimEvent";
-        entropyEvents.put(armorTrimEvent, ArmorTrimEvent::new);
-        requiredFeatures.put(armorTrimEvent, FeatureFlags.FEATURE_MANAGER.featureSetOf(FeatureFlags.UPDATE_1_20));
+        entropyEvents.put("ArmorTrimEvent", ArmorTrimEvent::new);
 
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/events/db/ArmorTrimEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/ArmorTrimEvent.java
@@ -15,9 +15,9 @@ public class ArmorTrimEvent extends AbstractInstantEvent {
     @Override
     public void init() {
         Entropy.getInstance().eventHandler.getActivePlayers().forEach(player -> {
-            World world = player.world;
+            World world = player.getWorld();
             Random random = world.random;
-            DynamicRegistryManager registryManager = player.world.getRegistryManager();
+            DynamicRegistryManager registryManager = player.getWorld().getRegistryManager();
             Registry<ArmorTrimMaterial> trimMaterials = registryManager.get(RegistryKeys.TRIM_MATERIAL);
             Registry<ArmorTrimPattern> trimPatterns = registryManager.get(RegistryKeys.TRIM_PATTERN);
 

--- a/src/main/java/me/juancarloscp52/entropy/events/db/ArmorTrimEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/ArmorTrimEvent.java
@@ -1,0 +1,27 @@
+package me.juancarloscp52.entropy.events.db;
+
+import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.events.AbstractInstantEvent;
+import net.minecraft.item.trim.ArmorTrim;
+import net.minecraft.item.trim.ArmorTrimMaterial;
+import net.minecraft.item.trim.ArmorTrimPattern;
+import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.World;
+
+public class ArmorTrimEvent extends AbstractInstantEvent {
+    @Override
+    public void init() {
+        Entropy.getInstance().eventHandler.getActivePlayers().forEach(player -> {
+            World world = player.world;
+            Random random = world.random;
+            DynamicRegistryManager registryManager = player.world.getRegistryManager();
+            Registry<ArmorTrimMaterial> trimMaterials = registryManager.get(RegistryKeys.TRIM_MATERIAL);
+            Registry<ArmorTrimPattern> trimPatterns = registryManager.get(RegistryKeys.TRIM_PATTERN);
+
+            player.getArmorItems().forEach(stack -> ArmorTrim.apply(registryManager, stack, new ArmorTrim(trimMaterials.getRandom(random).get(), trimPatterns.getRandom(random).get())));
+        });
+    }
+}

--- a/src/main/java/me/juancarloscp52/entropy/server/ServerEventHandler.java
+++ b/src/main/java/me/juancarloscp52/entropy/server/ServerEventHandler.java
@@ -129,7 +129,7 @@ public class ServerEventHandler {
     }
     
     public boolean runEvent(Event event) {
-        if(event != null) {
+        if(event != null && EventRegistry.doesWorldHaveRequiredFeatures(EventRegistry.getEventId(event), server.getOverworld())) {
             // Start the event and add it to the list.
             event.init();
             currentEvents.add(event);

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -159,6 +159,7 @@
   "entropy.events.SilenceEvent": "Stille",
   "entropy.events.NothingEvent": "Nichts",
   "entropy.events.RainbowTrailsEvent": "Regenbogenspuren",
+  "entropy.events.ArmorTrimEvent": "Verziert",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -159,6 +159,7 @@
   "entropy.events.SilenceEvent": "Stille",
   "entropy.events.NothingEvent": "Nichts",
   "entropy.events.RainbowTrailsEvent": "Regenbogenspuren",
+  "entropy.events.ArmorTrimEvent": "Verziert",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -159,6 +159,7 @@
   "entropy.events.SilenceEvent": "Stille",
   "entropy.events.NothingEvent": "Nichts",
   "entropy.events.RainbowTrailsEvent": "Regenbogenspuren",
+  "entropy.events.ArmorTrimEvent": "Verziert",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unbekanntes Ereignis: %s",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -160,6 +160,7 @@
   "entropy.events.NothingEvent": "Nothing",
   "entropy.events.RainbowTrailsEvent": "Rainbow Trails",
   "entropy.events.RainbowSheepEverywhereEvent": "jeb_",
+  "entropy.events.ArmorTrimEvent": "Trimmed",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Unknown event: %s",

--- a/src/main/resources/assets/entropy/lang/es_ar.json
+++ b/src/main/resources/assets/entropy/lang/es_ar.json
@@ -160,6 +160,7 @@
   "entropy.events.NothingEvent": "Nada",
   "entropy.events.RainbowTrailsEvent": "Cola arcoiris",
   "entropy.events.RainbowSheepEverywhereEvent": "jeb_",
+  "entropy.events.ArmorTrimEvent": "Tuneado",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Evento desconocido: %s",

--- a/src/main/resources/assets/entropy/lang/es_cl.json
+++ b/src/main/resources/assets/entropy/lang/es_cl.json
@@ -160,6 +160,7 @@
   "entropy.events.NothingEvent": "Nada",
   "entropy.events.RainbowTrailsEvent": "Cola arcoiris",
   "entropy.events.RainbowSheepEverywhereEvent": "jeb_",
+  "entropy.events.ArmorTrimEvent": "Tuneado",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Evento desconocido: %s",

--- a/src/main/resources/assets/entropy/lang/es_ec.json
+++ b/src/main/resources/assets/entropy/lang/es_ec.json
@@ -160,6 +160,7 @@
   "entropy.events.NothingEvent": "Nada",
   "entropy.events.RainbowTrailsEvent": "Cola arcoiris",
   "entropy.events.RainbowSheepEverywhereEvent": "jeb_",
+  "entropy.events.ArmorTrimEvent": "Tuneado",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Evento desconocido: %s",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -160,6 +160,7 @@
   "entropy.events.NothingEvent": "Nada",
   "entropy.events.RainbowTrailsEvent": "Cola arcoiris",
   "entropy.events.RainbowSheepEverywhereEvent": "jeb_",
+  "entropy.events.ArmorTrimEvent": "Tuneado",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Evento desconocido: %s",

--- a/src/main/resources/assets/entropy/lang/es_mx.json
+++ b/src/main/resources/assets/entropy/lang/es_mx.json
@@ -160,6 +160,7 @@
   "entropy.events.NothingEvent": "Nada",
   "entropy.events.RainbowTrailsEvent": "Cola arcoiris",
   "entropy.events.RainbowSheepEverywhereEvent": "jeb_",
+  "entropy.events.ArmorTrimEvent": "Tuneado",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Evento desconocido: %s",

--- a/src/main/resources/assets/entropy/lang/es_uy.json
+++ b/src/main/resources/assets/entropy/lang/es_uy.json
@@ -160,6 +160,7 @@
   "entropy.events.NothingEvent": "Nada",
   "entropy.events.RainbowTrailsEvent": "Cola arcoiris",
   "entropy.events.RainbowSheepEverywhereEvent": "jeb_",
+  "entropy.events.ArmorTrimEvent": "Tuneado",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Evento desconocido: %s",

--- a/src/main/resources/assets/entropy/lang/es_ve.json
+++ b/src/main/resources/assets/entropy/lang/es_ve.json
@@ -160,6 +160,7 @@
   "entropy.events.NothingEvent": "Nada",
   "entropy.events.RainbowTrailsEvent": "Cola arcoiris",
   "entropy.events.RainbowSheepEverywhereEvent": "jeb_",
+  "entropy.events.ArmorTrimEvent": "Tuneado",
 
   "entropy.title": "Entropy: Chaos Mod",
   "entropy.command.unknownEvent": "Evento desconocido: %s",


### PR DESCRIPTION
This PR first and foremost adds a new event that applies a random item trim to every armor item that the player is wearing. Armor that exists only in the player's inventory is not affected. Because armor trims are an experimental feature and locked behind the `update_1_20` datapack, the event is as well. To make this possible, I added a system for locking events behind feature flags. If an event requires a specific feature flag which is not enabled, it cannot be selected in a vote or at random, and it cannot be run manually via the command.