### PR TITLE
Fix teleport events

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/EntropyUtils.java
+++ b/src/main/java/me/juancarloscp52/entropy/EntropyUtils.java
@@ -1,0 +1,18 @@
+package me.juancarloscp52.entropy;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.Vec3d;
+
+import java.util.Set;
+
+public class EntropyUtils {
+
+    public static void teleportPlayer(final ServerPlayerEntity serverPlayerEntity, final double x, final double y, final double z) {
+        serverPlayerEntity.stopRiding();
+        serverPlayerEntity.teleport(serverPlayerEntity.getServerWorld(), x, y, z, Set.of(), serverPlayerEntity.getYaw(), serverPlayerEntity.getPitch());
+    }
+
+    public static void teleportPlayer(final ServerPlayerEntity serverPlayerEntity, final Vec3d pos) {
+        teleportPlayer(serverPlayerEntity, pos.getX(), pos.getY(), pos.getZ());
+    }
+}

--- a/src/main/java/me/juancarloscp52/entropy/events/db/LagEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/LagEvent.java
@@ -1,14 +1,17 @@
 package me.juancarloscp52.entropy.events.db;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.EntropyUtils;
 import me.juancarloscp52.entropy.events.AbstractTimedEvent;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.random.Random;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class LagEvent extends AbstractTimedEvent {
     Random random;
@@ -34,8 +37,7 @@ public class LagEvent extends AbstractTimedEvent {
             Entropy.getInstance().eventHandler.getActivePlayers().forEach((serverPlayerEntity) -> {
                 BlockPos pos = player_positions.get(serverPlayerEntity);
                 if (pos != null) {
-                    serverPlayerEntity.stopRiding();
-                    serverPlayerEntity.teleport(pos.getX(), pos.getY(), pos.getZ());
+                    EntropyUtils.teleportPlayer(serverPlayerEntity, Vec3d.ofBottomCenter(pos));
                 }
 
             });

--- a/src/main/java/me/juancarloscp52/entropy/events/db/SkyBlockEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/SkyBlockEvent.java
@@ -5,6 +5,7 @@
 package me.juancarloscp52.entropy.events.db;
 
 import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.EntropyUtils;
 import me.juancarloscp52.entropy.events.AbstractInstantEvent;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
@@ -15,8 +16,11 @@ import net.minecraft.item.Items;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraft.world.tick.ChunkTickScheduler;
+
+import java.util.Set;
 
 public class SkyBlockEvent extends AbstractInstantEvent {
 
@@ -143,8 +147,7 @@ public class SkyBlockEvent extends AbstractInstantEvent {
 
             var playerPos = startPos.add(-4, 3, 1);
 
-            serverPlayerEntity.stopRiding();
-            serverPlayerEntity.teleport(playerPos.getX() + .5, playerPos.getY(), playerPos.getZ() + .5);
+            EntropyUtils.teleportPlayer(serverPlayerEntity, Vec3d.ofBottomCenter(playerPos));
         }
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/events/db/SkyEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/SkyEvent.java
@@ -18,9 +18,11 @@
 package me.juancarloscp52.entropy.events.db;
 
 import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.EntropyUtils;
 import me.juancarloscp52.entropy.events.AbstractInstantEvent;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
 public class SkyEvent extends AbstractInstantEvent {
@@ -51,8 +53,7 @@ public class SkyEvent extends AbstractInstantEvent {
                     serverPlayerEntity.getWorld().setBlockState(new BlockPos(pos.getX()+i,pos.getY(),pos.getZ()+j),Blocks.GLASS.getDefaultState());
                 }
             }
-            serverPlayerEntity.stopRiding();
-            serverPlayerEntity.refreshPositionAfterTeleport(pos.getX(),pos.getY()+2,pos.getZ());
+            EntropyUtils.teleportPlayer(serverPlayerEntity, Vec3d.ofBottomCenter(pos.up(2)));
 
         });
     }

--- a/src/main/java/me/juancarloscp52/entropy/events/db/TeleportHeavenEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/TeleportHeavenEvent.java
@@ -18,6 +18,7 @@
 package me.juancarloscp52.entropy.events.db;
 
 import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.EntropyUtils;
 import me.juancarloscp52.entropy.events.AbstractInstantEvent;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.math.BlockPos;
@@ -40,8 +41,7 @@ public class TeleportHeavenEvent extends AbstractInstantEvent {
                 }
             }
 
-            serverPlayerEntity.stopRiding();
-            serverPlayerEntity.teleport(serverPlayerEntity.getX(), 380, serverPlayerEntity.getZ());
+            EntropyUtils.teleportPlayer(serverPlayerEntity, serverPlayerEntity.getX(), 380.0, serverPlayerEntity.getZ());
         });
     }
 }


### PR DESCRIPTION
Backported from the upgrade branch, but should work fine in older versions as well. Seems to build at least.

As far as I can tell, the base teleport method in the vanilla game is just broken in this version. The variant used in the to the moon event also didn't actually teleport all of the time, but would sometimes just apply fall damage as if you had teleported. Fun times!