### PR TITLE
Fix Teleport to Spawn Event

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/EntropyUtils.java
+++ b/src/main/java/me/juancarloscp52/entropy/EntropyUtils.java
@@ -1,7 +1,11 @@
 package me.juancarloscp52.entropy;
 
+import net.minecraft.block.Blocks;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.RaycastContext;
 
 import java.util.Set;
 
@@ -14,5 +18,14 @@ public class EntropyUtils {
 
     public static void teleportPlayer(final ServerPlayerEntity serverPlayerEntity, final Vec3d pos) {
         teleportPlayer(serverPlayerEntity, pos.getX(), pos.getY(), pos.getZ());
+    }
+
+    public static void clearPLayerArea(ServerPlayerEntity serverPlayerEntity){
+        serverPlayerEntity.getWorld().breakBlock(serverPlayerEntity.getBlockPos(), false);
+        serverPlayerEntity.getWorld().breakBlock(serverPlayerEntity.getBlockPos().up(), false);
+        BlockHitResult blockHitResult = serverPlayerEntity.getWorld().raycast(new RaycastContext(serverPlayerEntity.getPos(), serverPlayerEntity.getPos().subtract(0, -6, 0), RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.ANY, serverPlayerEntity));
+        if (blockHitResult.getType() == HitResult.Type.MISS || serverPlayerEntity.getWorld().getBlockState(blockHitResult.getBlockPos()).isLiquid()) {
+            serverPlayerEntity.getWorld().setBlockState(serverPlayerEntity.getBlockPos().down(), Blocks.STONE.getDefaultState());
+        }
     }
 }

--- a/src/main/java/me/juancarloscp52/entropy/events/db/FarRandomTPEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/FarRandomTPEvent.java
@@ -18,13 +18,10 @@
 package me.juancarloscp52.entropy.events.db;
 
 import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.EntropyUtils;
 import me.juancarloscp52.entropy.events.AbstractInstantEvent;
-import net.minecraft.block.Blocks;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.RaycastContext;
 
 import java.util.Random;
 
@@ -40,12 +37,7 @@ public class FarRandomTPEvent extends AbstractInstantEvent {
         Entropy.getInstance().eventHandler.getActivePlayers().forEach(serverPlayerEntity -> {
             serverPlayerEntity.stopRiding();
             server.getCommandManager().executeWithPrefix(server.getCommandSource(), "spreadplayers " + randomLocation.getX() + " " + randomLocation.getZ() + " 0 120 false " + serverPlayerEntity.getEntityName());
-            serverPlayerEntity.getWorld().breakBlock(serverPlayerEntity.getBlockPos(), false);
-            serverPlayerEntity.getWorld().breakBlock(serverPlayerEntity.getBlockPos().up(), false);
-            BlockHitResult blockHitResult = serverPlayerEntity.getWorld().raycast(new RaycastContext(serverPlayerEntity.getPos(), serverPlayerEntity.getPos().subtract(0, -6, 0), RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.ANY, serverPlayerEntity));
-            if (blockHitResult.getType() == HitResult.Type.MISS || serverPlayerEntity.getWorld().getBlockState(blockHitResult.getBlockPos()).isLiquid()) {
-                serverPlayerEntity.getWorld().setBlockState(serverPlayerEntity.getBlockPos().down(), Blocks.STONE.getDefaultState());
-            }
+            EntropyUtils.clearPLayerArea(serverPlayerEntity);
         });
 
     }
@@ -54,14 +46,7 @@ public class FarRandomTPEvent extends AbstractInstantEvent {
     public void tick() {
         if (count <= 2) {
             if (count == 2) {
-                Entropy.getInstance().eventHandler.getActivePlayers().forEach(serverPlayerEntity -> {
-                    serverPlayerEntity.getWorld().breakBlock(serverPlayerEntity.getBlockPos(), false);
-                    serverPlayerEntity.getWorld().breakBlock(serverPlayerEntity.getBlockPos().up(), false);
-                    BlockHitResult blockHitResult = serverPlayerEntity.getWorld().raycast(new RaycastContext(serverPlayerEntity.getPos(), serverPlayerEntity.getPos().subtract(0, -6, 0), RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.ANY, serverPlayerEntity));
-                    if (blockHitResult.getType() == HitResult.Type.MISS || serverPlayerEntity.getWorld().getBlockState(blockHitResult.getBlockPos()).isLiquid()) {
-                        serverPlayerEntity.getWorld().setBlockState(serverPlayerEntity.getBlockPos().down(), Blocks.STONE.getDefaultState());
-                    }
-                });
+                Entropy.getInstance().eventHandler.getActivePlayers().forEach(EntropyUtils::clearPLayerArea);
             }
             count++;
         }

--- a/src/main/java/me/juancarloscp52/entropy/events/db/Teleport0Event.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/Teleport0Event.java
@@ -18,12 +18,9 @@
 package me.juancarloscp52.entropy.events.db;
 
 import me.juancarloscp52.entropy.Entropy;
+import me.juancarloscp52.entropy.EntropyUtils;
 import me.juancarloscp52.entropy.events.AbstractInstantEvent;
-import net.minecraft.block.Blocks;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.hit.HitResult;
-import net.minecraft.world.RaycastContext;
 
 public class Teleport0Event extends AbstractInstantEvent {
 
@@ -34,14 +31,8 @@ public class Teleport0Event extends AbstractInstantEvent {
     public void init() {
         server = Entropy.getInstance().eventHandler.server;
         Entropy.getInstance().eventHandler.getActivePlayers().forEach(serverPlayerEntity -> {
-            serverPlayerEntity.stopRiding();
-            server.getCommandManager().executeWithPrefix(server.getCommandSource(), "spreadplayers 0 0 0 10 false " + serverPlayerEntity.getName().getString());
-            serverPlayerEntity.getWorld().breakBlock(serverPlayerEntity.getBlockPos(), false);
-            serverPlayerEntity.getWorld().breakBlock(serverPlayerEntity.getBlockPos().up(), false);
-            BlockHitResult blockHitResult = serverPlayerEntity.getWorld().raycast(new RaycastContext(serverPlayerEntity.getPos(), serverPlayerEntity.getPos().subtract(0, -6, 0), RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.ANY, serverPlayerEntity));
-            if (blockHitResult.getType() == HitResult.Type.MISS || serverPlayerEntity.getWorld().getBlockState(blockHitResult.getBlockPos()).isLiquid()) {
-                serverPlayerEntity.getWorld().setBlockState(serverPlayerEntity.getBlockPos().down(), Blocks.STONE.getDefaultState());
-            }
+            EntropyUtils.teleportPlayer(serverPlayerEntity, serverPlayerEntity.getServerWorld().getSpawnPos().toCenterPos());
+            EntropyUtils.clearPLayerArea(serverPlayerEntity);
         });
 
     }
@@ -50,14 +41,7 @@ public class Teleport0Event extends AbstractInstantEvent {
     public void tick() {
         if (count <= 2) {
             if (count == 2) {
-                Entropy.getInstance().eventHandler.getActivePlayers().forEach(serverPlayerEntity -> {
-                    serverPlayerEntity.getWorld().breakBlock(serverPlayerEntity.getBlockPos(), false);
-                    serverPlayerEntity.getWorld().breakBlock(serverPlayerEntity.getBlockPos().up(), false);
-                    BlockHitResult blockHitResult = serverPlayerEntity.getWorld().raycast(new RaycastContext(serverPlayerEntity.getPos(), serverPlayerEntity.getPos().subtract(0, -6, 0), RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.ANY, serverPlayerEntity));
-                    if (blockHitResult.getType() == HitResult.Type.MISS || serverPlayerEntity.getWorld().getBlockState(blockHitResult.getBlockPos()).isLiquid()) {
-                        serverPlayerEntity.getWorld().setBlockState(serverPlayerEntity.getBlockPos().down(), Blocks.STONE.getDefaultState());
-                    }
-                });
+                Entropy.getInstance().eventHandler.getActivePlayers().forEach(EntropyUtils::clearPLayerArea);
             }
             count++;
         }


### PR DESCRIPTION
Fix teleport to spawn event not working when the area around 0,0 is invalid (for example water). Instead get the world spawn point and teleport the player there. 

Clear teleport area logic has been extracted to EntropyUtils