### PR TITLE
Fix integrations not working

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/client/VotingClient.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/VotingClient.java
@@ -103,7 +103,7 @@ public class VotingClient {
         } else {
             this.overlayServer.onVoteEnd();
         }
-        if (this.size == events.size()) {
+        if (this.size - 1 == events.size()) {
             this.voteID = voteID;
             this.events = events;
             this.events.add("entropy.voting.randomEvent");


### PR DESCRIPTION
This is a regression introduced in #129.
 Previously, the amount of vote options [was written to the new poll packet](https://github.com/juancarloscp52/Entropy/commit/fe8947d9a008e3b2337151596c0c68e921bf386c#diff-adfb677121d4de19f5f2be781b5a81f6aa94cf32cde8369270064c3ee8585472L152-L155) (by default 4; 3 randomly selected events + "random event"), and then [used to check against the total expected amount of options in the vote](https://github.com/juancarloscp52/Entropy/commit/fe8947d9a008e3b2337151596c0c68e921bf386c#diff-4a5378b9ab94af880005aa1d588f9679a6b1854b734fc7325ef6edf7f49a304fL153-L158) after receiving it on the client. In the port to 1.20.6, for de-/serialization of the randomly selected events only their size was written to the packet, and then used to check against the total amount of vote options ([see here](https://github.com/juancarloscp52/Entropy/commit/fe8947d9a008e3b2337151596c0c68e921bf386c#diff-733d2067daba662e956c8333223d3e174e925517fbe31304d5b8e6dced526b0aR107)). Since the amount of available vote options will always be one more than the count of randomly selected events, the check now always fails.
This PR adjust it to compare against the expected amount of randomly selected events.