### PR TITLE
Fixes for event registry refactor

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/client/Screens/EntropyEventConfigurationScreen.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/Screens/EntropyEventConfigurationScreen.java
@@ -106,13 +106,17 @@ public class EntropyEventConfigurationScreen extends Screen {
 
     private void onCheckAll() {
         this.list.children().forEach(buttonEntry -> {
-            if (buttonEntry.checkbox.visible && !buttonEntry.checkbox.selected()) {buttonEntry.checkbox.onPress();}
+            if (buttonEntry.checkbox.visible && !buttonEntry.checkbox.selected() && buttonEntry.eventInfo.typeReference().value().isEnabled()) {
+                buttonEntry.checkbox.onPress();
+            }
         });
     }
 
     private void onUncheckAll() {
         this.list.children().forEach(buttonEntry -> {
-            if (buttonEntry.checkbox.visible && buttonEntry.checkbox.selected()) {buttonEntry.checkbox.onPress();}
+            if (buttonEntry.checkbox.visible && buttonEntry.checkbox.selected() && buttonEntry.eventInfo.typeReference().value().isEnabled()) {
+                buttonEntry.checkbox.onPress();
+            }
         });
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/client/Screens/Widgets/EntropyEventListWidget.java
+++ b/src/main/java/me/juancarloscp52/entropy/client/Screens/Widgets/EntropyEventListWidget.java
@@ -183,9 +183,11 @@ public class EntropyEventListWidget extends ContainerObjectSelectionList<Entropy
             EventType<?> type = typeReference.value();
             boolean isEnabled = type.isEnabled();
             boolean enableCheckbox = !isEventDisabledInSettings(typeReference) && isEnabled;
-            final Checkbox checkbox = Checkbox.builder(Component.translatable(type.getLanguageKey()), textRenderer).pos(0, 0).selected(enableCheckbox).onValueChange(isEnabled ? ButtonEntry::onDisabledCheckboxPressed : Checkbox.OnValueChange.NOP).build();
-            if (!isEnabled)
+            final Checkbox checkbox = Checkbox.builder(Component.translatable(type.getLanguageKey()), textRenderer).pos(0, 0).selected(enableCheckbox).build();
+            if (!isEnabled) {
                 checkbox.setTooltip(ACCESSIBILITY_TOOLTIP);
+                checkbox.active = false;
+            }
 
             return new EntropyEventListWidget.ButtonEntry(eventInfo, checkbox);
         }
@@ -195,12 +197,6 @@ public class EntropyEventListWidget extends ContainerObjectSelectionList<Entropy
                 .stream()
                 .map(ResourceKey::location)
                 .anyMatch(key -> typeReference.key().location().equals(key));
-        }
-
-        private static void onDisabledCheckboxPressed(Checkbox widget, boolean checked) {
-            if (checked) {
-                widget.onPress();
-            }
         }
 
         public void render(GuiGraphics drawContext, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Zufällige Rüstung",
   "events.entropy.force_front_view": "Vorderansicht erzwingen",
   "events.entropy.force_third_person": "Third-Person-Ansicht erzwingen",
-  "events.entropy.hides": "Was geschieht gerade!???",
+  "events.entropy.hide_events": "Was geschieht gerade!???",
   "events.entropy.top_down_view": "Vogelperspektive",
   "events.entropy.phantom": "Phantom-Truppe!",
   "events.entropy.timer_speed_2": "2x Timer-Geschwindigkeit",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Zufällige Rüstung",
   "events.entropy.force_front_view": "Vorderansicht erzwingen",
   "events.entropy.force_third_person": "Third-Person-Ansicht erzwingen",
-  "events.entropy.hides": "Was geschieht gerade!???",
+  "events.entropy.hide_events": "Was geschieht gerade!???",
   "events.entropy.top_down_view": "Vogelperspektive",
   "events.entropy.phantom": "Phantom-Truppe!",
   "events.entropy.timer_speed_2": "2x Timer-Geschwindigkeit",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Zufällige Rüstung",
   "events.entropy.force_front_view": "Vorderansicht erzwingen",
   "events.entropy.force_third_person": "Third-Person-Ansicht erzwingen",
-  "events.entropy.hides": "Was geschieht gerade!???",
+  "events.entropy.hide_events": "Was geschieht gerade!???",
   "events.entropy.top_down_view": "Vogelperspektive",
   "events.entropy.phantom": "Phantom-Truppe!",
   "events.entropy.timer_speed_2": "2x Timer-Geschwindigkeit",

--- a/src/main/resources/assets/entropy/lang/en_gb.json
+++ b/src/main/resources/assets/entropy/lang/en_gb.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Randomise armour",
   "events.entropy.force_front_view": "Force front view",
   "events.entropy.force_third_person": "Force third person view",
-  "events.entropy.hides": "What is happening?!",
+  "events.entropy.hide_events": "What is happening?!",
   "events.entropy.top_down_view": "Top down view",
   "events.entropy.phantom": "Phantom squad",
   "events.entropy.timer_speed_2": "2x timer speed",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Randomize Armor",
   "events.entropy.force_front_view": "Force Front View",
   "events.entropy.force_third_person": "Force Third Person View",
-  "events.entropy.hides": "What is happening!???",
+  "events.entropy.hide_events": "What is happening!???",
   "events.entropy.top_down_view": "Top Down View",
   "events.entropy.phantom": "Phantom Squad!",
   "events.entropy.timer_speed_2": "2x Timer Speed",

--- a/src/main/resources/assets/entropy/lang/es_ar.json
+++ b/src/main/resources/assets/entropy/lang/es_ar.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Armadura aleatoria",
   "events.entropy.force_front_view": "Forzar vista desde el frente",
   "events.entropy.force_third_person": "Forzar vista en tercera persona",
-  "events.entropy.hides": "Que está pasando!???",
+  "events.entropy.hide_events": "Que está pasando!???",
   "events.entropy.top_down_view": "Vista desde arriba",
   "events.entropy.phantom": "Escuadrón Fantasma!",
   "events.entropy.timer_speed_2": "2x Velocidad de contador",

--- a/src/main/resources/assets/entropy/lang/es_cl.json
+++ b/src/main/resources/assets/entropy/lang/es_cl.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Armadura aleatoria",
   "events.entropy.force_front_view": "Forzar vista desde el frente",
   "events.entropy.force_third_person": "Forzar vista en tercera persona",
-  "events.entropy.hides": "Que está pasando!???",
+  "events.entropy.hide_events": "Que está pasando!???",
   "events.entropy.top_down_view": "Vista desde arriba",
   "events.entropy.phantom": "Escuadrón Fantasma!",
   "events.entropy.timer_speed_2": "2x Velocidad de contador",

--- a/src/main/resources/assets/entropy/lang/es_ec.json
+++ b/src/main/resources/assets/entropy/lang/es_ec.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Armadura aleatoria",
   "events.entropy.force_front_view": "Forzar vista desde el frente",
   "events.entropy.force_third_person": "Forzar vista en tercera persona",
-  "events.entropy.hides": "Que está pasando!???",
+  "events.entropy.hide_events": "Que está pasando!???",
   "events.entropy.top_down_view": "Vista desde arriba",
   "events.entropy.phantom": "Escuadrón Fantasma!",
   "events.entropy.timer_speed_2": "2x Velocidad de contador",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Armadura aleatoria",
   "events.entropy.force_front_view": "Forzar vista desde el frente",
   "events.entropy.force_third_person": "Forzar vista en tercera persona",
-  "events.entropy.hides": "Que está pasando!???",
+  "events.entropy.hide_events": "Que está pasando!???",
   "events.entropy.top_down_view": "Vista desde arriba",
   "events.entropy.phantom": "Escuadrón Fantasma!",
   "events.entropy.timer_speed_2": "2x Velocidad de contador",

--- a/src/main/resources/assets/entropy/lang/es_mx.json
+++ b/src/main/resources/assets/entropy/lang/es_mx.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Armadura aleatoria",
   "events.entropy.force_front_view": "Forzar vista desde el frente",
   "events.entropy.force_third_person": "Forzar vista en tercera persona",
-  "events.entropy.hides": "Que está pasando!???",
+  "events.entropy.hide_events": "Que está pasando!???",
   "events.entropy.top_down_view": "Vista desde arriba",
   "events.entropy.phantom": "Escuadrón Fantasma!",
   "events.entropy.timer_speed_2": "2x Velocidad de contador",

--- a/src/main/resources/assets/entropy/lang/es_uy.json
+++ b/src/main/resources/assets/entropy/lang/es_uy.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Armadura aleatoria",
   "events.entropy.force_front_view": "Forzar vista desde el frente",
   "events.entropy.force_third_person": "Forzar vista en tercera persona",
-  "events.entropy.hides": "Que está pasando!???",
+  "events.entropy.hide_events": "Que está pasando!???",
   "events.entropy.top_down_view": "Vista desde arriba",
   "events.entropy.phantom": "Escuadrón Fantasma!",
   "events.entropy.timer_speed_2": "2x Velocidad de contador",

--- a/src/main/resources/assets/entropy/lang/es_ve.json
+++ b/src/main/resources/assets/entropy/lang/es_ve.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Armadura aleatoria",
   "events.entropy.force_front_view": "Forzar vista desde el frente",
   "events.entropy.force_third_person": "Forzar vista en tercera persona",
-  "events.entropy.hides": "Que está pasando!???",
+  "events.entropy.hide_events": "Que está pasando!???",
   "events.entropy.top_down_view": "Vista desde arriba",
   "events.entropy.phantom": "Escuadrón Fantasma!",
   "events.entropy.timer_speed_2": "2x Velocidad de contador",

--- a/src/main/resources/assets/entropy/lang/pt_br.json
+++ b/src/main/resources/assets/entropy/lang/pt_br.json
@@ -56,7 +56,7 @@
   "events.entropy.randomize_armor": "Aleatorizar armadura",
   "events.entropy.force_front_view": "Olhe para si mesmo",
   "events.entropy.force_third_person": "Forçar visão em terceira pessoa",
-  "events.entropy.hides": "O que está acontecendo!???",
+  "events.entropy.hide_events": "O que está acontecendo!???",
   "events.entropy.top_down_view": "Visão de cima",
   "events.entropy.phantom": "Esquadrão fantasma!",
   "events.entropy.timer_speed_2": "Velocidade do temporizador 2x",

--- a/src/main/resources/assets/entropy/lang/zh_cn.json
+++ b/src/main/resources/assets/entropy/lang/zh_cn.json
@@ -55,7 +55,7 @@
   "events.entropy.randomize_armor": "随便穿点什么吧",
   "events.entropy.force_front_view": "强制第二人称视角",
   "events.entropy.force_third_person": "强制第三人称视角",
-  "events.entropy.hides": "何者将至?",
+  "events.entropy.hide_events": "何者将至?",
   "events.entropy.top_down_view": "俯视图",
   "events.entropy.phantom": "幻翼小队!",
   "events.entropy.timer_speed_2": "2x 计时器速度",


### PR DESCRIPTION
Here are fixes for some bugs that slipped through the cracks:
- The events config screen stopped working properly. It was not possible to re-enable events if they were not disabled by accessibility mode (so the exact opposite of how it should be)
- The language key for the `entropy:hide_events` event was incorrect