### PR TITLE
Fix teleport to spawn not teleporting to the actual world spawn

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/EntropyUtils.java
+++ b/src/main/java/me/juancarloscp52/entropy/EntropyUtils.java
@@ -1,5 +1,6 @@
 package me.juancarloscp52.entropy;
 
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
@@ -16,12 +17,20 @@ import java.util.stream.Stream;
 public class EntropyUtils {
 
     public static void teleportPlayer(final ServerPlayer serverPlayerEntity, final double x, final double y, final double z) {
+        teleportPlayer(serverPlayerEntity, serverPlayerEntity.level(), x, y, z);
+    }
+
+    public static void teleportPlayer(final ServerPlayer serverPlayerEntity, final ServerLevel level, final double x, final double y, final double z) {
         serverPlayerEntity.stopRiding();
-        serverPlayerEntity.teleportTo(serverPlayerEntity.level(), x, y, z, Set.of(), serverPlayerEntity.getYRot(), serverPlayerEntity.getXRot(), true);
+        serverPlayerEntity.teleportTo(level, x, y, z, Set.of(), serverPlayerEntity.getYRot(), serverPlayerEntity.getXRot(), true);
     }
 
     public static void teleportPlayer(final ServerPlayer serverPlayerEntity, final Vec3 pos) {
-        teleportPlayer(serverPlayerEntity, pos.x(), pos.y(), pos.z());
+        teleportPlayer(serverPlayerEntity, serverPlayerEntity.level(), pos.x(), pos.y(), pos.z());
+    }
+
+    public static void teleportPlayer(final ServerPlayer serverPlayerEntity, final ServerLevel level, final Vec3 pos) {
+        teleportPlayer(serverPlayerEntity, level, pos.x(), pos.y(), pos.z());
     }
 
     public static void clearPlayerArea(ServerPlayer serverPlayerEntity){

--- a/src/main/java/me/juancarloscp52/entropy/events/db/Teleport0Event.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/Teleport0Event.java
@@ -22,6 +22,8 @@ import me.juancarloscp52.entropy.EntropyUtils;
 import me.juancarloscp52.entropy.events.AbstractInstantEvent;
 import me.juancarloscp52.entropy.events.EventType;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
 
 public class Teleport0Event extends AbstractInstantEvent {
 
@@ -33,7 +35,8 @@ public class Teleport0Event extends AbstractInstantEvent {
     public void init() {
         server = Entropy.getInstance().eventHandler.server;
         Entropy.getInstance().eventHandler.getActivePlayers().forEach(serverPlayerEntity -> {
-            EntropyUtils.teleportPlayer(serverPlayerEntity, serverPlayerEntity.level().getSharedSpawnPos().getCenter());
+            ServerLevel overworld = serverPlayerEntity.getServer().getLevel(Level.OVERWORLD);
+            EntropyUtils.teleportPlayer(serverPlayerEntity, overworld, overworld.getSharedSpawnPos().getCenter());
             EntropyUtils.clearPlayerArea(serverPlayerEntity);
         });
 


### PR DESCRIPTION
Previously, this event teleported the player to the spawn coordinates within the dimension the player is currently in. With this change, all players are teleported to the overworld spawn no matter in which dimension they are.