### PR TITLE
Fixes for fake teleport events

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/Event.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/Event.java
@@ -72,7 +72,7 @@ public interface Event {
 
         int size = client.font.width(eventName);
         drawContext.drawString(client.font, eventName, client.getWindow().getGuiScaledWidth() - size - 40, y, CommonColors.WHITE);
-        if (!this.hasEnded()) {
+        if (!this.hasEnded() && getDuration() > 0) {
             drawContext.fill(client.getWindow().getGuiScaledWidth() - 35, y + 1, client.getWindow().getGuiScaledWidth() - 5, y + 8, ARGB.color(150,70, 70, 70));
             drawContext.fill(client.getWindow().getGuiScaledWidth() - 35, y + 1, client.getWindow().getGuiScaledWidth() - 35 + Mth.floor(30 * (getTickCount() / (double) getDuration())), y + 8, ARGB.color(200,255, 255, 255));
         }

--- a/src/main/java/me/juancarloscp52/entropy/events/Event.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/Event.java
@@ -91,6 +91,10 @@ public interface Event {
         return description;
     }
 
+    default Component getVoteDescription() {
+        return getDescription();
+    }
+
     void tick();
 
     @Environment(EnvType.CLIENT)

--- a/src/main/java/me/juancarloscp52/entropy/events/db/FakeFakeTeleportEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/FakeFakeTeleportEvent.java
@@ -3,8 +3,10 @@ package me.juancarloscp52.entropy.events.db;
 import me.juancarloscp52.entropy.events.AbstractInstantEvent;
 import me.juancarloscp52.entropy.events.EventType;
 import me.juancarloscp52.entropy.events.db.FakeTeleportEvent.TeleportInfo;
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.server.level.ServerPlayer;
 
@@ -56,7 +58,17 @@ public class FakeFakeTeleportEvent extends AbstractInstantEvent {
 
     @Override
     public Component getDescription() {
-        return hasEnded() ? super.getDescription() : fakeTeleportEvent.getDescription();
+        return hasEnded() ? getVoteDescription() : fakeTeleportEvent.getDescription();
+    }
+
+    @Override
+    public Component getVoteDescription() {
+        final MutableComponent description = Component.translatable(getType().getLanguageKey() + ".vote", fakeTeleportEvent.teleportEvent.getDescription());
+        if (!getType().isEnabled()) {
+            return description.withStyle(ChatFormatting.STRIKETHROUGH);
+        }
+
+        return description;
     }
 
     @Override

--- a/src/main/java/me/juancarloscp52/entropy/events/db/FakeTeleportEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/FakeTeleportEvent.java
@@ -5,9 +5,11 @@ import me.juancarloscp52.entropy.events.AbstractInstantEvent;
 import me.juancarloscp52.entropy.events.Event;
 import me.juancarloscp52.entropy.events.EventRegistry;
 import me.juancarloscp52.entropy.events.EventType;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.server.level.ServerPlayer;
 
@@ -69,7 +71,17 @@ public class FakeTeleportEvent extends AbstractInstantEvent {
 
     @Override
     public Component getDescription() {
-        return hasEnded() ? super.getDescription() : teleportEvent.getDescription();
+        return hasEnded() ? getVoteDescription() : teleportEvent.getDescription();
+    }
+
+    @Override
+    public Component getVoteDescription() {
+        final MutableComponent description = Component.translatable(getType().getLanguageKey() + ".vote", teleportEvent.getDescription());
+        if (!getType().isEnabled()) {
+            return description.withStyle(ChatFormatting.STRIKETHROUGH);
+        }
+
+        return description;
     }
 
     @Override

--- a/src/main/java/me/juancarloscp52/entropy/server/VotingServer.java
+++ b/src/main/java/me/juancarloscp52/entropy/server/VotingServer.java
@@ -149,7 +149,7 @@ public class VotingServer {
     public ClientboundNewPoll getNewPollPacket() {
         return new ClientboundNewPoll(voteID, events.isEmpty()
             ? List.of(Component.translatable("entropy.votes.no_event"))
-            : events.stream().map(Event::getDescription).toList()
+            : events.stream().map(Event::getVoteDescription).toList()
         );
     }
 

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -151,6 +151,8 @@
   "events.entropy.creative_flight": "Zeit zum Fliegen!",
   "events.entropy.fake_teleport": "Vorgetäuschte Teleportation",
   "events.entropy.fake_fake_teleport": "Vorgetäuschte vorgetäuschte Teleportation",
+  "events.entropy.fake_teleport.vote": "%s (Vorgetäuschte Teleportation)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Vorgetäuschte vorgetäuschte Teleportation)",
   "events.entropy.forcefield": "Kraftfeld",
   "events.entropy.entity_magnet": "Entitätenmagnet",
   "events.entropy.one_punch": "Ein Schlag",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -151,6 +151,8 @@
   "events.entropy.creative_flight": "Zeit zum Fliegen!",
   "events.entropy.fake_teleport": "Vorgetäuschte Teleportation",
   "events.entropy.fake_fake_teleport": "Vorgetäuschte vorgetäuschte Teleportation",
+  "events.entropy.fake_teleport.vote": "%s (Vorgetäuschte Teleportation)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Vorgetäuschte vorgetäuschte Teleportation)",
   "events.entropy.forcefield": "Kraftfeld",
   "events.entropy.entity_magnet": "Entitätenmagnet",
   "events.entropy.one_punch": "Ein Schlag",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -151,6 +151,8 @@
   "events.entropy.creative_flight": "Zeit zum Fliegen!",
   "events.entropy.fake_teleport": "Vorgetäuschte Teleportation",
   "events.entropy.fake_fake_teleport": "Vorgetäuschte vorgetäuschte Teleportation",
+  "events.entropy.fake_teleport.vote": "%s (Vorgetäuschte Teleportation)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Vorgetäuschte vorgetäuschte Teleportation)",
   "events.entropy.forcefield": "Kraftfeld",
   "events.entropy.entity_magnet": "Entitätenmagnet",
   "events.entropy.one_punch": "Ein Schlag",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -151,6 +151,8 @@
   "events.entropy.creative_flight": "Time To Fly!",
   "events.entropy.fake_teleport": "Fake Teleport",
   "events.entropy.fake_fake_teleport": "Fake Fake Teleport",
+  "events.entropy.fake_teleport.vote": "%s (Fake Teleport)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Fake Fake Teleport)",
   "events.entropy.forcefield": "Forcefield",
   "events.entropy.entity_magnet": "Entity Magnet",
   "events.entropy.one_punch": "One Punch",

--- a/src/main/resources/assets/entropy/lang/es_ar.json
+++ b/src/main/resources/assets/entropy/lang/es_ar.json
@@ -151,6 +151,8 @@
   "events.entropy.so_sweet": "¡Que dulce!",
   "events.entropy.fake_teleport": "Teletransporte falso",
   "events.entropy.fake_fake_teleport": "Falso teletransporte falso",
+  "events.entropy.fake_teleport.vote": "%s (Teletransporte falso)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Falso teletransporte falso)",
   "events.entropy.forcefield": "Campo de fuerza",
   "events.entropy.entity_magnet": "Imán de entidates",
   "events.entropy.one_punch": "De un puñetazo",

--- a/src/main/resources/assets/entropy/lang/es_cl.json
+++ b/src/main/resources/assets/entropy/lang/es_cl.json
@@ -151,6 +151,8 @@
   "events.entropy.so_sweet": "¡Que dulce!",
   "events.entropy.fake_teleport": "Teletransporte falso",
   "events.entropy.fake_fake_teleport": "Falso teletransporte falso",
+  "events.entropy.fake_teleport.vote": "%s (Teletransporte falso)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Falso teletransporte falso)",
   "events.entropy.forcefield": "Campo de fuerza",
   "events.entropy.entity_magnet": "Imán de entidates",
   "events.entropy.one_punch": "De un puñetazo",

--- a/src/main/resources/assets/entropy/lang/es_ec.json
+++ b/src/main/resources/assets/entropy/lang/es_ec.json
@@ -151,6 +151,8 @@
   "events.entropy.so_sweet": "¡Que dulce!",
   "events.entropy.fake_teleport": "Teletransporte falso",
   "events.entropy.fake_fake_teleport": "Falso teletransporte falso",
+  "events.entropy.fake_teleport.vote": "%s (Teletransporte falso)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Falso teletransporte falso)",
   "events.entropy.forcefield": "Campo de fuerza",
   "events.entropy.entity_magnet": "Imán de entidates",
   "events.entropy.one_punch": "De un puñetazo",

--- a/src/main/resources/assets/entropy/lang/es_es.json
+++ b/src/main/resources/assets/entropy/lang/es_es.json
@@ -151,6 +151,8 @@
   "events.entropy.so_sweet": "¡Que dulce!",
   "events.entropy.fake_teleport": "Teletransporte falso",
   "events.entropy.fake_fake_teleport": "Falso teletransporte falso",
+  "events.entropy.fake_teleport.vote": "%s (Teletransporte falso)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Falso teletransporte falso)",
   "events.entropy.forcefield": "Campo de fuerza",
   "events.entropy.entity_magnet": "Imán de entidates",
   "events.entropy.one_punch": "De un puñetazo",

--- a/src/main/resources/assets/entropy/lang/es_mx.json
+++ b/src/main/resources/assets/entropy/lang/es_mx.json
@@ -151,6 +151,8 @@
   "events.entropy.so_sweet": "¡Que dulce!",
   "events.entropy.fake_teleport": "Teletransporte falso",
   "events.entropy.fake_fake_teleport": "Falso teletransporte falso",
+  "events.entropy.fake_teleport.vote": "%s (Teletransporte falso)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Falso teletransporte falso)",
   "events.entropy.forcefield": "Campo de fuerza",
   "events.entropy.entity_magnet": "Imán de entidates",
   "events.entropy.one_punch": "De un puñetazo",

--- a/src/main/resources/assets/entropy/lang/es_uy.json
+++ b/src/main/resources/assets/entropy/lang/es_uy.json
@@ -151,6 +151,8 @@
   "events.entropy.so_sweet": "¡Que dulce!",
   "events.entropy.fake_teleport": "Teletransporte falso",
   "events.entropy.fake_fake_teleport": "Falso teletransporte falso",
+  "events.entropy.fake_teleport.vote": "%s (Teletransporte falso)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Falso teletransporte falso)",
   "events.entropy.forcefield": "Campo de fuerza",
   "events.entropy.entity_magnet": "Imán de entidates",
   "events.entropy.one_punch": "De un puñetazo",

--- a/src/main/resources/assets/entropy/lang/es_ve.json
+++ b/src/main/resources/assets/entropy/lang/es_ve.json
@@ -151,6 +151,8 @@
   "events.entropy.so_sweet": "¡Que dulce!",
   "events.entropy.fake_teleport": "Teletransporte falso",
   "events.entropy.fake_fake_teleport": "Falso teletransporte falso",
+  "events.entropy.fake_teleport.vote": "%s (Teletransporte falso)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Falso teletransporte falso)",
   "events.entropy.forcefield": "Campo de fuerza",
   "events.entropy.entity_magnet": "Imán de entidates",
   "events.entropy.one_punch": "De un puñetazo",

--- a/src/main/resources/assets/entropy/lang/pt_br.json
+++ b/src/main/resources/assets/entropy/lang/pt_br.json
@@ -151,6 +151,8 @@
   "events.entropy.creative_flight": "Hora de voar!",
   "events.entropy.fake_teleport": "Teleporte falso",
   "events.entropy.fake_fake_teleport": "Teleporte falso falso",
+  "events.entropy.fake_teleport.vote": "%s (Teleporte falso)",
+  "events.entropy.fake_fake_teleport.vote": "%s (Teleporte falso falso)",
   "events.entropy.forcefield": "Repelente de entidades",
   "events.entropy.entity_magnet": "Ímã de entidades",
   "events.entropy.one_punch": "Um soco = um morto",

--- a/src/main/resources/assets/entropy/lang/ru_ru.json
+++ b/src/main/resources/assets/entropy/lang/ru_ru.json
@@ -151,6 +151,8 @@
     "events.entropy.creative_flight": "Время полетать!",
     "events.entropy.fake_teleport": "Фальшивый телепорт",
     "events.entropy.fake_fake_teleport": "Фальшивый фальшивый телепорт",
+    "events.entropy.fake_teleport.vote": "%s (Фальшивый телепорт)",
+    "events.entropy.fake_fake_teleport.vote": "%s (Фальшивый фальшивый телепорт)",
     "events.entropy.forcefield": "Силовое поле",
     "events.entropy.entity_magnet": "Магнит для сущностей",
     "events.entropy.one_punch": "С одного удара",
@@ -161,7 +163,7 @@
     "events.entropy.rainbow_trails": "Радужный след",
     "events.entropy.rainbow_sheep_everywhere": "jeb_",
     "events.entropy.armor_trim": "Украсить броню",
-  
+
     "entropy.title": "Entropy: мод на хаос",
     "entropy.command.unknownEvent": "Неизвестное событие: %s",
     "entropy.command.invalidClientSide": "Событие %s не может быть запущено в одиночной игре",
@@ -191,7 +193,7 @@
     "entropy.options.integrations.youtube.returnToGame": "Токен доступа получен, вы можете закрыть вкладку и вернуться к игре.",
     "entropy.options.integrations.youtube.error.auth": "Авторизация провалилась",
     "entropy.options.integrations.youtube.quotaExceeded": "Квота превышена",
-  
+
     "entropy.options.disableEvents": "Выключить события",
     "entropy.options.search": "Поиск...",
     "entropy.options.eventDuration": "Период события: %d с",


### PR DESCRIPTION
This PR includes two fixes, each in their own commit. Both bugs were likely caused by the changes of #142.

1. Previously, fake teleport events would only say "Fake Teleport" in the vote options. Through the PR, this changed to always showing the underlying teleport event, meaning viewers could not see that the event they were voting for is a fake teleport. This is now changed so the vote contains info about which teleport event is being voted for, and the fact it is a fake one. The event queue now also says that the event was fake, but only after the fact.
2. Because of that PR, the progress bar is rendered for all events that have not ended. This is now amended to include a check for event duration. If the event has not ended and the duration is 0, then there is no progress to be rendered (the bar would be empty), and as such no bar should be rendered.