### PR TITLE
Disable the blur event with accessibility mode

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/db/BlurEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/BlurEvent.java
@@ -23,7 +23,7 @@ import me.juancarloscp52.entropy.events.EventCategory;
 import me.juancarloscp52.entropy.events.EventType;
 
 public class BlurEvent extends AbstractTimedEvent {
-    public static final EventType<BlurEvent> TYPE = EventType.builder(BlurEvent::new).category(EventCategory.SHADER).build();
+    public static final EventType<BlurEvent> TYPE = EventType.builder(BlurEvent::new).category(EventCategory.SHADER).disabledByAccessibilityMode().build();
 
     @Override
     public void initClient() {


### PR DESCRIPTION
Some people mentioned in slicedlime's stream yesterday that they feel dizzy looking at the screen, so this should be a reasonable change.