### PR TITLE
Fix random tp event not working without having operator permissions

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/db/RandomTPEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/RandomTPEvent.java
@@ -21,6 +21,7 @@ import me.juancarloscp52.entropy.Entropy;
 import me.juancarloscp52.entropy.EntropyUtils;
 import me.juancarloscp52.entropy.events.AbstractInstantEvent;
 import me.juancarloscp52.entropy.events.EventType;
+import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
@@ -55,12 +56,13 @@ public class RandomTPEvent extends AbstractInstantEvent {
         Entropy.getInstance().eventHandler.getActivePlayers().forEach(player -> {
             String netherSafety = "";
             DimensionType dimensionType = player.level().dimensionType();
+            CommandSourceStack commandSourceStack = player.createCommandSourceStack().withPermission(4);
 
             if (dimensionType.hasCeiling())
                 netherSafety = " under " + (dimensionType.logicalHeight() - 1);
 
             player.stopRiding();
-            Entropy.getInstance().eventHandler.server.getCommands().performPrefixedCommand(player.createCommandSourceStack(), "spreadplayers " + player.position().x() + " " + player.position().z() + " 0 " + distance.value() + netherSafety + " false " + player.getName().getString());
+            Entropy.getInstance().eventHandler.server.getCommands().performPrefixedCommand(commandSourceStack, "spreadplayers " + player.position().x() + " " + player.position().z() + " 0 " + distance.value() + netherSafety + " false " + player.getName().getString());
             EntropyUtils.clearPlayerArea(player);
         });
     }

--- a/src/main/resources/assets/entropy/lang/de_at.json
+++ b/src/main/resources/assets/entropy/lang/de_at.json
@@ -1,6 +1,7 @@
 {
   "events.entropy.upside_down": "Kopfüber",
   "events.entropy.creeper": "Creeper!",
+  "events.entropy.random_tp": "Spieler zufällig teleportieren",
   "events.entropy.random_tp.close": "Spieler ein paar Meter teleportieren",
   "events.entropy.random_tp.far": "Spieler an einen zufälligen Ort teleportieren",
   "events.entropy.teleport_spawn": "Zum Spawn teleportieren",

--- a/src/main/resources/assets/entropy/lang/de_ch.json
+++ b/src/main/resources/assets/entropy/lang/de_ch.json
@@ -1,6 +1,7 @@
 {
   "events.entropy.upside_down": "Kopfüber",
   "events.entropy.creeper": "Creeper!",
+  "events.entropy.random_tp": "Spieler zufällig teleportieren",
   "events.entropy.random_tp.close": "Spieler ein paar Meter teleportieren",
   "events.entropy.random_tp.far": "Spieler an einen zufälligen Ort teleportieren",
   "events.entropy.teleport_spawn": "Zum Spawn teleportieren",

--- a/src/main/resources/assets/entropy/lang/de_de.json
+++ b/src/main/resources/assets/entropy/lang/de_de.json
@@ -1,6 +1,7 @@
 {
   "events.entropy.upside_down": "Kopfüber",
   "events.entropy.creeper": "Creeper!",
+  "events.entropy.random_tp": "Spieler zufällig teleportieren",
   "events.entropy.random_tp.close": "Spieler ein paar Meter teleportieren",
   "events.entropy.random_tp.far": "Spieler an einen zufälligen Ort teleportieren",
   "events.entropy.teleport_spawn": "Zum Spawn teleportieren",

--- a/src/main/resources/assets/entropy/lang/en_us.json
+++ b/src/main/resources/assets/entropy/lang/en_us.json
@@ -1,6 +1,7 @@
 {
   "events.entropy.upside_down": "Upside down",
   "events.entropy.creeper": "Creeper!",
+  "events.entropy.random_tp": "Teleport Player Randomly",
   "events.entropy.random_tp.close": "Teleport Player A Few Meters",
   "events.entropy.random_tp.far": "Teleport Player To A Random Location",
   "events.entropy.teleport_spawn": "Teleport To Spawn",


### PR DESCRIPTION
This bug is most easily reproducible in a singleplayer world without cheats. The PR also adds a missing language entry, which is used in the event settings.