### PR TITLE
Fix ballon race and no drops events not ending correctly

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/db/BalloonRaceEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/BalloonRaceEvent.java
@@ -38,6 +38,7 @@ public class BalloonRaceEvent extends AbstractTimedEvent {
 
     @Override
     public void end() {
+        super.end();
         ghasts.forEach(happyGhast -> happyGhast.remove(Entity.RemovalReason.DISCARDED));
     }
 

--- a/src/main/java/me/juancarloscp52/entropy/events/db/NoDropsEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/NoDropsEvent.java
@@ -33,7 +33,7 @@ public class NoDropsEvent extends AbstractTimedEvent {
     @Override
     public void end() {
         Variables.noDrops = false;
-        super.endClient();
+        super.end();
     }
 
     @Override


### PR DESCRIPTION
The Balloon Race event not being set to have ended causes the event list to not be cleared at all. See https://www.youtube.com/watch?v=UGt23ugDnhQ&t=2h52m56s

Not sure if there are any issues with No Drops, but the code called the wrong super method either way so I fixed that, too.