### PR TITLE
Check for replacability before spawning a pet

### DIFF
--- a/src/main/java/me/juancarloscp52/entropy/events/db/SpawnPetEvent.java
+++ b/src/main/java/me/juancarloscp52/entropy/events/db/SpawnPetEvent.java
@@ -6,11 +6,14 @@ import me.juancarloscp52.entropy.events.EventType;
 import me.juancarloscp52.entropy.mixin.CatInvoker;
 import me.juancarloscp52.entropy.mixin.WolfInvoker;
 import net.minecraft.Util;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
@@ -61,17 +64,32 @@ public class SpawnPetEvent extends AbstractInstantEvent {
     public void init() {
         Entropy.getInstance().eventHandler.getActivePlayers().forEach(player -> {
             RandomSource random = player.getRandom();
-
-            petType.spawn(player.level(), pet -> {
-                pet.tame(player);
-                // Some stuff that doesn't have an interface in the base game
-                if (pet instanceof Cat cat) {
-                    ((CatInvoker) cat).invokeSetCollarColor(Util.getRandom(DyeColor.values(), random));
-                } else if (pet instanceof Wolf wolf) {
-                    ((WolfInvoker) wolf).invokeSetCollarColor(Util.getRandom(DyeColor.values(), random));
+            BlockPos playerPos = player.blockPosition();
+            for (int i = 0; i < 10; i++) {
+                BlockPos position = playerPos.offset(random.nextIntBetweenInclusive(-4, 4), random.nextInt(2), random.nextIntBetweenInclusive(-4, 4));
+                if (trySpawn(player, position, random)) {
+                    return;
                 }
-            }, player.blockPosition().offset(random.nextIntBetweenInclusive(-4, 4), random.nextInt(2), random.nextIntBetweenInclusive(-4, 4)), EntitySpawnReason.EVENT, false, false);
+            }
+            trySpawn(player, playerPos, random);
         });
+    }
+
+    private boolean trySpawn(ServerPlayer player, BlockPos position, RandomSource random) {
+        ServerLevel level = player.level();
+        if (!level.noCollision(petType.getSpawnAABB(position.getX() + 0.5f, position.getY(), position.getZ() + 0.5f))) {
+            return false;
+        }
+        petType.spawn(level, pet -> {
+            pet.tame(player);
+            // Some stuff that doesn't have an interface in the base game
+            if (pet instanceof Cat cat) {
+                ((CatInvoker) cat).invokeSetCollarColor(Util.getRandom(DyeColor.values(), random));
+            } else if (pet instanceof Wolf wolf) {
+                ((WolfInvoker) wolf).invokeSetCollarColor(Util.getRandom(DyeColor.values(), random));
+            }
+        }, position, EntitySpawnReason.EVENT, false, false);
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Previously, a random position around the player was chosen and the pet spawned. This could have resulted in the pet spawning in a wall and suffocating horribly. This PR changes the spawning logic to check at most 10 random potential spawn positions. If a block is found where the pet will not suffocate in, the pet is spawned. If not, the pet is spawned at the player's feet, as that is likely to be safe to spawn, but the same check is still made there anyway. While replacability does not encompass all blocks that are safe to spawn in (e.g. end rods), I think it's a reasonable middle ground.